### PR TITLE
Bring changes to bayes_search from `core` into client

### DIFF
--- a/bayes_search.py
+++ b/bayes_search.py
@@ -260,10 +260,12 @@ def next_sample(
     # hack for dealing with predicted std of 0
     epsilon = 0.00000001
 
+    """
     if opt_func == "probability_of_improvement":
         min_norm_y = (min_unnorm_y - y_mean) / y_stddev - improvement
     else:
-        min_norm_y = (min_unnorm_y - y_mean) / y_stddev
+    """
+    min_norm_y = (min_unnorm_y - y_mean) / y_stddev
 
     Z = -(y_pred - min_norm_y) / (y_pred_std + epsilon)
     prob_of_improve: np.ndarray = scipy_stats.norm.cdf(Z)
@@ -271,10 +273,12 @@ def next_sample(
         Z
     ) + y_pred_std * scipy_stats.norm.pdf(Z)
 
+    """
     if opt_func == "probability_of_improvement":
         best_test_X_index = np.argmax(prob_of_improve)
     else:
-        best_test_X_index = np.argmax(e_i)
+    """
+    best_test_X_index = np.argmax(e_i)
 
     suggested_X = test_X[best_test_X_index]
     suggested_X_prob_of_improvement = prob_of_improve[best_test_X_index]

--- a/run.py
+++ b/run.py
@@ -38,7 +38,7 @@ class SweepRun(BaseModel):
     """
 
     name: Optional[str] = None
-    summary_metrics: dict = Field(default_factory=lambda: {})
+    summary_metrics: dict = Field(default_factory=lambda: {}, alias="summaryMetrics")
     history: List[dict] = Field(default_factory=lambda: [])
     config: dict = Field(default_factory=lambda: {})
     state: RunState = RunState.proposed

--- a/run.py
+++ b/run.py
@@ -47,6 +47,7 @@ class SweepRun(BaseModel):
 
     class Config:
         use_enum_values = True
+        allow_population_by_field_name = True
 
     def metric_history(self, metric_name: str) -> List[floating]:
         return [d[metric_name] for d in self.history if metric_name in d]

--- a/tests/test_bayes_search.py
+++ b/tests/test_bayes_search.py
@@ -113,15 +113,7 @@ def run_iterations(
         for cc in range(chunk_size):
             if counter >= num_iterations:
                 break
-            (
-                sample,
-                prob,
-                pred,
-                samples,
-                vals,
-                stds,
-                sample_probs,
-            ) = bayes.next_sample(
+            (sample, prob, pred, _, _,) = bayes.next_sample(
                 sample_X=X,
                 sample_y=y,
                 X_bounds=bounds,
@@ -155,7 +147,7 @@ def test_squiggle_explores_parameter_space():
     # we sample a ton of positive examples, ignoring the negative side
     X = np.random.uniform(0, 5, 200)[:, None]
     Y = squiggle(X.ravel())
-    (sample, prob, pred, samples, vals, stds, sample_probs,) = bayes.next_sample(
+    (sample, prob, pred, _, _,) = bayes.next_sample(
         sample_X=X, sample_y=Y, X_bounds=[[-5.0, 5.0]], improvement=1.0
     )
     assert sample[0] < 0.0, "Greater than 0 {}".format(sample[0])
@@ -168,10 +160,8 @@ def test_squiggle_explores_parameter_space():
         sample,
         prob,
         pred,
-        samples,
-        vals,
-        stds,
-        sample_probs,
+        _,
+        _,
     ) = bayes.next_sample(sample_X=X, sample_y=Y, X_bounds=[[0.0, 5.0]])
     assert (
         sample[0] > 1.0 and sample[0] < 4.0


### PR DESCRIPTION
* Synchronizes the implementation of `bayes_search` with the latest version from core https://github.com/wandb/core/tree/396d4792278e1d206752d08b8b75e38d1d2be8f5/services/anaconda
* Adds an automatic converter from camelCase to snake_case in the `pydantic` Run parser, fixing a bug in which runs passed from gorilla to anaconda2 did not have their `summaryMetrics` picked up because they were formatted in camel case and not snake case 