### PR TITLE
Let strict jsonschema validation of passed sweep configs  be configurable

### DIFF
--- a/bayes_search.py
+++ b/bayes_search.py
@@ -316,6 +316,7 @@ def next_sample(
 def bayes_search_next_run(
     runs: List[SweepRun],
     config: Union[dict, SweepConfig],
+    validate: bool = True,
     minimum_improvement: float = 0.1,
 ) -> SweepRun:
     """Suggest runs using Bayesian optimization.
@@ -330,12 +331,16 @@ def bayes_search_next_run(
         runs: The runs in the sweep.
         config: The sweep's config.
         minimum_improvement: The minimium improvement to optimize for. Higher means take more exploratory risks.
+        validate: Whether to validate `sweep_config` against the SweepConfig JSONschema.
+           If true, will raise a Validation error if `sweep_config` does not conform to
+           the schema. If false, will attempt to run the sweep with an unvalidated schema.
 
     Returns:
         The suggested run.
     """
 
-    config = SweepConfig(config)
+    if validate:
+        config = SweepConfig(config)
 
     if "metric" not in config:
         raise ValueError('Bayesian search requires "metric" section')

--- a/bayes_search.py
+++ b/bayes_search.py
@@ -316,7 +316,7 @@ def next_sample(
 def bayes_search_next_run(
     runs: List[SweepRun],
     config: Union[dict, SweepConfig],
-    validate: bool = True,
+    validate: bool = False,
     minimum_improvement: float = 0.1,
 ) -> SweepRun:
     """Suggest runs using Bayesian optimization.

--- a/grid_search.py
+++ b/grid_search.py
@@ -10,7 +10,7 @@ from .params import HyperParameter, HyperParameterSet
 def grid_search_next_run(
     runs: List[SweepRun],
     sweep_config: Union[dict, SweepConfig],
-    validate: bool = True,
+    validate: bool = False,
     randomize_order: bool = False,
 ) -> Optional[SweepRun]:
     """Suggest runs with Hyperparameters drawn from a grid.

--- a/grid_search.py
+++ b/grid_search.py
@@ -10,6 +10,7 @@ from .params import HyperParameter, HyperParameterSet
 def grid_search_next_run(
     runs: List[SweepRun],
     sweep_config: Union[dict, SweepConfig],
+    validate: bool = True,
     randomize_order: bool = False,
 ) -> Optional[SweepRun]:
     """Suggest runs with Hyperparameters drawn from a grid.
@@ -21,13 +22,17 @@ def grid_search_next_run(
         runs: The runs in the sweep.
         sweep_config: The sweep's config.
         randomize_order: Whether to randomize the order of the grid search.
+        validate: Whether to validate `sweep_config` against the SweepConfig JSONschema.
+           If true, will raise a Validation error if `sweep_config` does not conform to
+           the schema. If false, will attempt to run the sweep with an unvalidated schema.
 
     Returns:
         The suggested run.
     """
 
     # make sure the sweep config is valid
-    sweep_config = SweepConfig(sweep_config)
+    if validate:
+        sweep_config = SweepConfig(sweep_config)
 
     if sweep_config["method"] != "grid":
         raise ValueError("Invalid sweep configuration for grid_search_next_run.")

--- a/hyperband_stopping.py
+++ b/hyperband_stopping.py
@@ -9,6 +9,7 @@ from .run import SweepRun, RunState
 def hyperband_stop_runs(
     runs: List[SweepRun],
     config: Union[dict, SweepConfig],
+    validate: bool = True,
 ) -> List[SweepRun]:
     """
     Suggest sweep runs to terminate early using Hyperband: A Novel Bandit-Based Approach to Hyperparameter Optimization
@@ -75,13 +76,17 @@ def hyperband_stop_runs(
     Args:
         runs: The runs in the sweep.
         config: The sweep's config.
+        validate: Whether to validate `sweep_config` against the SweepConfig JSONschema.
+           If true, will raise a Validation error if `sweep_config` does not conform to
+           the schema. If false, will attempt to run the sweep with an unvalidated schema.
 
     Returns:
         List of runs to stop early.
     """
 
     # validate config and fill in defaults
-    config = SweepConfig(config)
+    if validate:
+        config = SweepConfig(config)
 
     if "metric" not in config:
         raise ValueError('Hyperband stopping requires "metric" section')

--- a/hyperband_stopping.py
+++ b/hyperband_stopping.py
@@ -9,7 +9,7 @@ from .run import SweepRun, RunState
 def hyperband_stop_runs(
     runs: List[SweepRun],
     config: Union[dict, SweepConfig],
-    validate: bool = True,
+    validate: bool = False,
 ) -> List[SweepRun]:
     """
     Suggest sweep runs to terminate early using Hyperband: A Novel Bandit-Based Approach to Hyperparameter Optimization

--- a/params.py
+++ b/params.py
@@ -36,7 +36,7 @@ class HyperParameter:
     BETA = "param_beta"
     Q_BETA = "param_qbeta"
 
-    def __init__(self, name: str, config: dict, validate: bool = True):
+    def __init__(self, name: str, config: dict):
         """A hyperparameter to optimize.
 
         >>> parameter = HyperParameter('int_unif_distributed', {'min': 1, 'max': 10})

--- a/params.py
+++ b/params.py
@@ -36,7 +36,7 @@ class HyperParameter:
     BETA = "param_beta"
     Q_BETA = "param_qbeta"
 
-    def __init__(self, name: str, config: dict):
+    def __init__(self, name: str, config: dict, validate: bool = True):
         """A hyperparameter to optimize.
 
         >>> parameter = HyperParameter('int_unif_distributed', {'min': 1, 'max': 10})
@@ -72,11 +72,12 @@ class HyperParameter:
                 filler = DefaultFiller(subschema, format_checker=format_checker)
 
                 # this sets the defaults, modifying config inplace
+                config = deepcopy(config)
                 filler.validate(config)
 
                 valid = True
                 self.type = schema_name
-                self.config = deepcopy(config)
+                self.config = config
 
         if not valid:
             raise jsonschema.ValidationError("invalid hyperparameter configuration")

--- a/random_search.py
+++ b/random_search.py
@@ -6,7 +6,7 @@ from typing import Union
 
 
 def random_search_next_run(
-    sweep_config: Union[dict, SweepConfig], validate: bool = True
+    sweep_config: Union[dict, SweepConfig], validate: bool = False
 ) -> SweepRun:
     """Suggest runs with Hyperparameters sampled randomly from specified distributions.
 

--- a/random_search.py
+++ b/random_search.py
@@ -5,20 +5,26 @@ from .params import HyperParameterSet
 from typing import Union
 
 
-def random_search_next_run(sweep_config: Union[dict, SweepConfig]) -> SweepRun:
+def random_search_next_run(
+    sweep_config: Union[dict, SweepConfig], validate: bool = True
+) -> SweepRun:
     """Suggest runs with Hyperparameters sampled randomly from specified distributions.
 
     >>> suggestion = random_search_next_run({'method': 'random', 'parameters': {'a': {'min': 1., 'max': 2.}}})
 
     Args:
         sweep_config: The sweep's config.
+        validate: Whether to validate `sweep_config` against the SweepConfig JSONschema.
+           If true, will raise a Validation error if `sweep_config` does not conform to
+           the schema. If false, will attempt to run the sweep with an unvalidated schema.
 
     Returns:
         The suggested run.
     """
 
     # ensure that the sweepconfig is properly formatted
-    sweep_config = SweepConfig(sweep_config)
+    if validate:
+        sweep_config = SweepConfig(sweep_config)
 
     if sweep_config["method"] != "random":
         raise ValueError("Invalid sweep configuration for random_search_next_run.")

--- a/run.py
+++ b/run.py
@@ -95,7 +95,10 @@ class SweepRun(BaseModel):
 
 
 def next_run(
-    sweep_config: Union[dict, SweepConfig], runs: List[SweepRun], **kwargs
+    sweep_config: Union[dict, SweepConfig],
+    runs: List[SweepRun],
+    validate: bool = True,
+    **kwargs,
 ) -> Optional[SweepRun]:
     """Calculate the next run in a sweep.
 
@@ -108,6 +111,9 @@ def next_run(
     Args:
         sweep_config: The config for the sweep.
         runs: List of runs in the sweep.
+        validate: Whether to validate `sweep_config` against the SweepConfig JSONschema.
+           If true, will raise a Validation error if `sweep_config` does not conform to
+           the schema. If false, will attempt to run the sweep with an unvalidated schema.
 
     Returns:
         The suggested run.
@@ -118,17 +124,18 @@ def next_run(
     from .bayes_search import bayes_search_next_run
 
     # validate the sweep config
-    sweep_config = SweepConfig(sweep_config)
+    if validate:
+        sweep_config = SweepConfig(sweep_config)
 
     # this access is safe due to the jsonschema
     method = sweep_config["method"]
 
     if method == "grid":
-        return grid_search_next_run(runs, sweep_config, **kwargs)
+        return grid_search_next_run(runs, sweep_config, validate=validate, **kwargs)
     elif method == "random":
-        return random_search_next_run(sweep_config)
+        return random_search_next_run(sweep_config, validate=validate)
     elif method == "bayes":
-        return bayes_search_next_run(runs, sweep_config, **kwargs)
+        return bayes_search_next_run(runs, sweep_config, validate=validate, **kwargs)
     else:
         raise ValueError(
             f'Invalid search type {method}, must be one of ["grid", "random", "bayes"]'
@@ -138,6 +145,7 @@ def next_run(
 def stop_runs(
     sweep_config: Union[dict, SweepConfig],
     runs: List[SweepRun],
+    validate: bool = True,
 ) -> List[SweepRun]:
     """Calculate the runs in a sweep to stop by early termination.
 
@@ -201,6 +209,10 @@ def stop_runs(
     Args:
         sweep_config: The config for the sweep.
         runs: List of runs in the sweep.
+        validate: Whether to validate `sweep_config` against the SweepConfig JSONschema.
+           If true, will raise a Validation error if `sweep_config` does not conform to
+           the schema. If false, will attempt to run the sweep with an unvalidated schema.
+
 
     Returns:
         A list of the runs to stop.
@@ -209,7 +221,8 @@ def stop_runs(
     from .hyperband_stopping import hyperband_stop_runs
 
     # validate the sweep config
-    sweep_config = SweepConfig(sweep_config)
+    if validate:
+        sweep_config = SweepConfig(sweep_config)
 
     if "metric" not in sweep_config:
         raise ValueError('early terminate requires "metric" section')
@@ -219,7 +232,7 @@ def stop_runs(
     et_type = sweep_config["early_terminate"]["type"]
 
     if et_type == "hyperband":
-        return hyperband_stop_runs(runs, sweep_config)
+        return hyperband_stop_runs(runs, sweep_config, validate=validate)
     else:
         raise ValueError(
             f'Invalid early stopping type {et_type}, must be one of ["hyperband"]'

--- a/run.py
+++ b/run.py
@@ -97,7 +97,7 @@ class SweepRun(BaseModel):
 def next_run(
     sweep_config: Union[dict, SweepConfig],
     runs: List[SweepRun],
-    validate: bool = True,
+    validate: bool = False,
     **kwargs,
 ) -> Optional[SweepRun]:
     """Calculate the next run in a sweep.
@@ -145,7 +145,7 @@ def next_run(
 def stop_runs(
     sweep_config: Union[dict, SweepConfig],
     runs: List[SweepRun],
-    validate: bool = True,
+    validate: bool = False,
 ) -> List[SweepRun]:
     """Calculate the runs in a sweep to stop by early termination.
 

--- a/tests/test_bayes_search.py
+++ b/tests/test_bayes_search.py
@@ -86,7 +86,7 @@ def test_squiggle_convergence_full(x):
         }
     )
 
-    run_bayes_search(y, config, runs, num_iterations=50, optimium={"x": 2.0})
+    run_bayes_search(y, config, runs, num_iterations=200, optimium={"x": 2.0})
 
 
 def run_iterations(

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -75,3 +75,10 @@ def test_json_type_inference_beta():
     assert param.config["b"] == 1
     assert param.type == HyperParameter.BETA
     assert len(param.config) == 3
+
+
+def test_validate_does_not_modify_passed_config():
+    config = {"distribution": "normal"}
+    config_save = config.copy()
+    _ = HyperParameter("normal_test", config)
+    assert config == config_save

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,6 +1,10 @@
 import pytest
 from jsonschema import ValidationError
-from .. import next_run
+from .. import next_run, stop_runs
+from ..bayes_search import bayes_search_next_run
+from ..grid_search import grid_search_next_run
+from ..random_search import random_search_next_run
+from ..hyperband_stopping import hyperband_stop_runs
 
 
 @pytest.mark.parametrize("search_type", ["bayes", "grid", "random"])
@@ -15,6 +19,18 @@ def test_validation_disable(search_type):
 
     with pytest.raises(ValidationError):
         _ = next_run(invalid_schema, [], validate=True)
+
+    with pytest.raises(ValidationError):
+        _ = stop_runs(invalid_schema, [], validate=True)
+        _ = hyperband_stop_runs([], invalid_schema, validate=True)
+
+    with pytest.raises(ValidationError):
+        if search_type == "bayes":
+            _ = bayes_search_next_run([], invalid_schema, validate=True)
+        elif search_type == "grid":
+            _ = grid_search_next_run([], invalid_schema, validate=True)
+        elif search_type == "random":
+            _ = random_search_next_run(invalid_schema, validate=True)
 
     # check that no error is raised
     result = next_run(invalid_schema, [], validate=False)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,21 @@
+import pytest
+from jsonschema import ValidationError
+from .. import next_run
+
+
+@pytest.mark.parametrize("search_type", ["bayes", "grid", "random"])
+def test_validation_disable(search_type):
+    invalid_schema = {
+        "metric": {"name": "loss", "goal": "minimise"},
+        "method": search_type,
+        "parameters": {
+            "v1": {"values": ["a", "b", "c"]},
+        },
+    }
+
+    with pytest.raises(ValidationError):
+        _ = next_run(invalid_schema, [])
+
+    # check that no error is raised
+    result = next_run(invalid_schema, [], validate=False)
+    assert result is not None

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -14,7 +14,7 @@ def test_validation_disable(search_type):
     }
 
     with pytest.raises(ValidationError):
-        _ = next_run(invalid_schema, [])
+        _ = next_run(invalid_schema, [], validate=True)
 
     # check that no error is raised
     result = next_run(invalid_schema, [], validate=False)


### PR DESCRIPTION
This PR adds a keyword argument to the main sweep-related methods that controls whether to enforce strict validation of schema compliance for sweep configs. If disabled, this should come close to replicating old behavior in anaconda1 of running potentially unsafe code but doing the best job possible to run the sweep with the given config. If we decide to enforce strict compliance at some point we can simply flip these bits and schema enforcement will be done strictly.

This PR also fixes a small bug whereby jsonschema default filling modified the original passed dict instead of making a copy and modifying that. 

Testing
Added unittest for both of the cases above 