### PR TITLE
Handle preempted/preemptible runs in `bayes_search`

### DIFF
--- a/bayes_search.py
+++ b/bayes_search.py
@@ -377,7 +377,7 @@ def bayes_search_next_run(
                 metric = 0.0  # default
             y.append(metric)
             sample_X.append(X_norm)
-        elif run.state == RunState.running:
+        elif run.state in [RunState.running, RunState.preempting, RunState.preempted]:
             # run is in progress
             # we wont use the metric, but we should pass it into our optimizer to
             # account for the fact that it is running

--- a/tests/test_bayes_search.py
+++ b/tests/test_bayes_search.py
@@ -485,3 +485,62 @@ def test_runs_bayes_categorical_list():
 
     assert best_x[0] == ["5", "6"]
     assert np.abs(best_x[1] - 10) < 0.2
+
+
+def test_bayes_can_handle_preemptible_or_preempting_runs():
+
+    v2_min = 1
+    v2_max = 10
+
+    config = {
+        "method": "bayes",
+        "metric": {
+            "name": "acc",
+            "goal": "maximize",
+        },
+        "parameters": {
+            "v1": {
+                "distribution": "categorical",
+                "values": [(2, 3), [3, 4], ["5", "6"], [(7, 8), ["9", [10, 11]]]],
+            },
+            "v2": {"min": v2_min, "max": v2_max},
+        },
+    }
+
+    def loss_func(x: SweepRun) -> floating:
+        v2_acc = 0.5 * (x.config["v2"]["value"] - v2_min) / (v2_max - v2_min)
+        v1_acc = [0.1, 0.2, 0.5, 0.1][
+            config["parameters"]["v1"]["values"].index(x.config["v1"]["value"])
+        ]
+        return v1_acc + v2_acc
+
+    r1 = SweepRun(
+        name="b",
+        state=RunState.preempted,
+        config={"v1": {"value": [3, 4]}, "v2": {"value": 5}},
+        history=[],
+    )
+    r1.summary_metrics = {"acc": loss_func(r1)}
+
+    # this should not raise, and should produce the same result as if r1.state was running
+    seed = np.random.get_state()
+    pred = next_run(config, [r1])
+    r1.state = RunState.running
+    np.random.set_state(seed)
+    true = next_run(config, [r1])
+    assert pred.config == true.config
+
+    r2 = SweepRun(
+        name="b",
+        state=RunState.preempting,
+        config={"v1": {"value": (2, 3)}, "v2": {"value": 5}},
+        history=[],
+    )
+    r2.summary_metrics = {"acc": loss_func(r2)}
+
+    seed = np.random.get_state()
+    pred = next_run(config, [r2])
+    r2.state = RunState.running
+    np.random.set_state(seed)
+    true = next_run(config, [r2])
+    assert pred.config == true.config


### PR DESCRIPTION
This PR adds code to handle runs that are in the `preempted` or `preempting` state to `bayes_search`, treating them as in-flight runs. This prevents their results from being taken as final, but also tells the optimizer that there are active runs in a certain area of parameter space, so it should avoid sampling new runs close by.