### PR TITLE
[CLI-975] make distinguishing between `uniform` and `int_uniform` distributions safe

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,6 +1,11 @@
 # -*- coding: utf-8 -*-
 """Sweep config interface."""
 from .cfg import SweepConfig, schema_violations_from_proposed_config
-from .schema import fill_schema
+from .schema import fill_schema, fill_parameter
 
-__all__ = ["SweepConfig", "schema_violations_from_proposed_config", "fill_schema"]
+__all__ = [
+    "SweepConfig",
+    "schema_violations_from_proposed_config",
+    "fill_schema",
+    "fill_parameter",
+]

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 """Sweep config interface."""
 from .cfg import SweepConfig, schema_violations_from_proposed_config
+from .schema import fill_schema
 
-__all__ = [
-    "SweepConfig",
-    "schema_violations_from_proposed_config",
-]
+__all__ = ["SweepConfig", "schema_violations_from_proposed_config", "fill_schema"]

--- a/config/cfg.py
+++ b/config/cfg.py
@@ -32,8 +32,6 @@ def schema_violations_from_proposed_config(config: Dict) -> List[str]:
 
 class SweepConfig(dict):
     def __init__(self, d: Dict):
-        super(SweepConfig, self).__init__(deepcopy(d))
-
         if not isinstance(d, SweepConfig):
             # ensure the data conform to the schema
             schema_violation_messages = schema_violations_from_proposed_config(d)
@@ -41,6 +39,8 @@ class SweepConfig(dict):
             if len(schema_violation_messages) > 0:
                 err_msg = "\n".join(schema_violation_messages)
                 raise jsonschema.ValidationError(err_msg)
+
+        super(SweepConfig, self).__init__(deepcopy(d))
 
     def __str__(self) -> str:
         return yaml.safe_dump(self)

--- a/config/cfg.py
+++ b/config/cfg.py
@@ -7,6 +7,7 @@ from typing import Union, Dict, List
 
 import jsonschema
 from .schema import validator
+from copy import deepcopy
 
 
 def schema_violations_from_proposed_config(config: Dict) -> List[str]:
@@ -31,7 +32,7 @@ def schema_violations_from_proposed_config(config: Dict) -> List[str]:
 
 class SweepConfig(dict):
     def __init__(self, d: Dict):
-        super(SweepConfig, self).__init__(d)
+        super(SweepConfig, self).__init__(deepcopy(d))
 
         if not isinstance(d, SweepConfig):
             # ensure the data conform to the schema

--- a/config/schema.json
+++ b/config/schema.json
@@ -20,7 +20,8 @@
         "distribution": {
           "enum": [
             "categorical"
-          ]
+          ],
+          "default": "categorical"
         }
       },
       "additionalProperties": false
@@ -342,7 +343,9 @@
           ]
         }
       },
-      "required": ["distribution"],
+      "required": [
+        "distribution"
+      ],
       "additionalProperties": false
     },
     "param_qbeta": {
@@ -371,7 +374,9 @@
           ]
         }
       },
-      "required": ["distribution"],
+      "required": [
+        "distribution"
+      ],
       "additionalProperties": false
     },
     "parameter": {

--- a/config/schema.json
+++ b/config/schema.json
@@ -199,6 +199,12 @@
             "max": {
               "type": "number",
               "format": "float"
+            },
+            "distribution": {
+              "enum": [
+                "uniform"
+              ],
+              "default": "uniform"
             }
           },
           "additionalProperties": false

--- a/config/schema.json
+++ b/config/schema.json
@@ -559,7 +559,7 @@
       "additionalProperties": {
         "$ref": "#/definitions/parameter"
       },
-      "minLength": 1
+      "minProperties": 1
     }
   }
 }

--- a/config/schema.json
+++ b/config/schema.json
@@ -558,7 +558,8 @@
       },
       "additionalProperties": {
         "$ref": "#/definitions/parameter"
-      }
+      },
+      "minLength": 1
     }
   }
 }

--- a/config/schema.json
+++ b/config/schema.json
@@ -38,7 +38,8 @@
         "distribution": {
           "enum": [
             "constant"
-          ]
+          ],
+          "default": "constant"
         }
       },
       "additionalProperties": false
@@ -341,6 +342,7 @@
           ]
         }
       },
+      "required": ["distribution"],
       "additionalProperties": false
     },
     "param_qbeta": {
@@ -369,6 +371,7 @@
           ]
         }
       },
+      "required": ["distribution"],
       "additionalProperties": false
     },
     "parameter": {

--- a/config/schema.json
+++ b/config/schema.json
@@ -160,30 +160,50 @@
       "additionalProperties": false
     },
     "param_uniform": {
-      "type": "object",
-      "description": "uniform distribution on real numbers",
-      "required": [
-        "min",
-        "max"
-      ],
-      "properties": {
-        "min": {
-          "description": "float",
-          "type": "number",
-          "format": "float"
+      "anyOf": [
+        {
+          "type": "object",
+          "description": "uniform distribution on real numbers",
+          "required": [
+            "min",
+            "max",
+            "distribution"
+          ],
+          "properties": {
+            "min": {
+              "type": "number"
+            },
+            "max": {
+              "type": "number"
+            },
+            "distribution": {
+              "enum": [
+                "uniform"
+              ]
+            }
+          },
+          "additionalProperties": false
         },
-        "max": {
-          "description": "float",
-          "type": "number",
-          "format": "float"
-        },
-        "distribution": {
-          "enum": [
-            "uniform"
-          ]
+        {
+          "type": "object",
+          "description": "uniform distribution on real numbers",
+          "required": [
+            "min",
+            "max"
+          ],
+          "properties": {
+            "min": {
+              "type": "number",
+              "format": "float"
+            },
+            "max": {
+              "type": "number",
+              "format": "float"
+            }
+          },
+          "additionalProperties": false
         }
-      },
-      "additionalProperties": false
+      ]
     },
     "param_loguniform": {
       "type": "object",
@@ -346,19 +366,45 @@
     },
     "parameter": {
       "anyOf": [
-        {"$ref":  "#/definitions/param_qbeta"},
-        {"$ref":  "#/definitions/param_beta"},
-        {"$ref":  "#/definitions/param_categorical"},
-        {"$ref":  "#/definitions/param_int_uniform"},
-        {"$ref":  "#/definitions/param_uniform"},
-        {"$ref":  "#/definitions/param_lognormal"},
-        {"$ref":  "#/definitions/param_loguniform"},
-        {"$ref":  "#/definitions/param_normal"},
-        {"$ref":  "#/definitions/param_qlognormal"},
-        {"$ref":  "#/definitions/param_qloguniform"},
-        {"$ref":  "#/definitions/param_qnormal"},
-        {"$ref":  "#/definitions/param_quniform"},
-        {"$ref":  "#/definitions/param_single_value"}
+        {
+          "$ref": "#/definitions/param_qbeta"
+        },
+        {
+          "$ref": "#/definitions/param_beta"
+        },
+        {
+          "$ref": "#/definitions/param_categorical"
+        },
+        {
+          "$ref": "#/definitions/param_int_uniform"
+        },
+        {
+          "$ref": "#/definitions/param_uniform"
+        },
+        {
+          "$ref": "#/definitions/param_lognormal"
+        },
+        {
+          "$ref": "#/definitions/param_loguniform"
+        },
+        {
+          "$ref": "#/definitions/param_normal"
+        },
+        {
+          "$ref": "#/definitions/param_qlognormal"
+        },
+        {
+          "$ref": "#/definitions/param_qloguniform"
+        },
+        {
+          "$ref": "#/definitions/param_qnormal"
+        },
+        {
+          "$ref": "#/definitions/param_quniform"
+        },
+        {
+          "$ref": "#/definitions/param_single_value"
+        }
       ]
     },
     "hyperband_stopping": {
@@ -489,7 +535,9 @@
     },
     "early_terminate": {
       "oneOf": [
-        {"$ref":  "#/definitions/hyperband_stopping"}
+        {
+          "$ref": "#/definitions/hyperband_stopping"
+        }
       ]
     },
     "parameters": {
@@ -498,7 +546,9 @@
       "propertyNames": {
         "pattern": "^^[A-Za-z_][A-Za-z0-9_.-]*$"
       },
-      "additionalProperties": {"$ref": "#/definitions/parameter"}
+      "additionalProperties": {
+        "$ref": "#/definitions/parameter"
+      }
     }
   }
 }

--- a/config/schema.json
+++ b/config/schema.json
@@ -315,7 +315,8 @@
         "distribution": {
           "enum": [
             "int_uniform"
-          ]
+          ],
+          "default": "int_uniform"
         }
       },
       "additionalProperties": false

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -5,14 +5,18 @@ def test_json_type_inference_int_uniform():
     config = {"min": 0, "max": 1}
     param = HyperParameter("int_unif_param", config)
     assert param.type == HyperParameter.INT_UNIFORM
-    assert len(param.config) == 2
+
+    # len is 3 because distribution key is inferred via default
+    assert len(param.config) == 3
 
 
 def test_json_type_inference_uniform():
     config = {"min": 0.0, "max": 1.0}
     param = HyperParameter("unif_param", config)
     assert param.type == HyperParameter.UNIFORM
-    assert len(param.config) == 2
+
+    # len is 3 because distribution key is inferred via default
+    assert len(param.config) == 3
 
 
 def test_json_type_inference_and_imputation_normal():
@@ -37,16 +41,17 @@ def test_json_type_inference_categorical():
     config = {"values": [1, 2, 3]}
     param = HyperParameter("categorical_param", config)
     assert param.type == HyperParameter.CATEGORICAL
-    # TODO(dag): infer distribution key via default
-    assert len(param.config) == 1
+    # len is 2 because distribution key is inferred via default
+    assert len(param.config) == 2
 
 
 def test_json_type_inference_constant():
     config = {"value": "abcd"}
     param = HyperParameter("constant_param", config)
     assert param.type == HyperParameter.CONSTANT
-    # TODO(dag): infer distribution key via default
-    assert len(param.config) == 1
+
+    # len is 2 because distribution key is inferred via default
+    assert len(param.config) == 2
 
 
 def test_json_type_inference_q_normal():

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -104,10 +104,21 @@ def test_uniform_with_integer_min_max():
 def test_fill_schema():
     config = {"method": "random", "parameters": {"a": {"min": 0, "max": 1}}}
     filled = fill_schema(config)
+    assert "distribution" in filled["parameters"]["a"]
     assert filled["parameters"]["a"]["distribution"] == "int_uniform"
     config = {"method": "random", "parameters": {"a": {"min": 0.0, "max": 1.0}}}
     filled = fill_schema(config)
+    assert "distribution" in filled["parameters"]["a"]
     assert filled["parameters"]["a"]["distribution"] == "uniform"
     config = {"method": "random", "parameters": {"a": {"min": 0.0, "max": 1}}}
     with pytest.raises(jsonschema.ValidationError):
         fill_schema(config)
+
+    config = {
+        "method": "bayes",
+        "parameters": {"a": {"min": 0.0, "max": 1.0}},
+        "early_terminate": {"type": "hyperband", "min_iter": 2},
+    }
+    filled = fill_schema(config)
+    assert "eta" in filled["early_terminate"]
+    assert filled["early_terminate"]["eta"] == 3

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,4 +1,8 @@
+import jsonschema
+import pytest
+
 from ..params import HyperParameter
+from ..config import fill_schema
 
 
 def test_json_type_inference_int_uniform():
@@ -95,3 +99,15 @@ def test_uniform_with_integer_min_max():
     config = {"distribution": "uniform", "min": 0, "max": 1}  # integers
     unif_param = HyperParameter("uniform_param", config)  # this should not raise
     assert unif_param.type == HyperParameter.UNIFORM
+
+
+def test_fill_schema():
+    config = {"method": "random", "parameters": {"a": {"min": 0, "max": 1}}}
+    filled = fill_schema(config)
+    assert filled["parameters"]["a"]["distribution"] == "int_uniform"
+    config = {"method": "random", "parameters": {"a": {"min": 0.0, "max": 1.0}}}
+    filled = fill_schema(config)
+    assert filled["parameters"]["a"]["distribution"] == "uniform"
+    config = {"method": "random", "parameters": {"a": {"min": 0.0, "max": 1}}}
+    with pytest.raises(jsonschema.ValidationError):
+        fill_schema(config)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -82,3 +82,11 @@ def test_validate_does_not_modify_passed_config():
     config_save = config.copy()
     _ = HyperParameter("normal_test", config)
     assert config == config_save
+
+
+def test_uniform_with_integer_min_max():
+    # CLI-975
+    # https://github.com/wandb/sweeps/pull/16
+    config = {"distribution": "uniform", "min": 0, "max": 1}  # integers
+    unif_param = HyperParameter("uniform_param", config)  # this should not raise
+    assert unif_param.type == HyperParameter.UNIFORM


### PR DESCRIPTION
When a user passes integer`min`/`max` values for a sweep parameter explicitly declared with `distribution: "uniform"` the backend throws warnings like:

```
wandb: WARNING To avoid this, please fix the sweep config schema violations below:
wandb: WARNING   Violation 1. {'distribution': 'uniform', 'max': -18, 'min': -20} is not valid under any of the given schemas
wandb: WARNING   Violation 2. {'distribution': 'uniform', 'max': 0.01, 'min': 0} is not valid under any of the given schemas
wandb: WARNING   Violation 3. {'distribution': 'uniform', 'max': 0.05, 'min': 0} is not valid under any of the given schemas
wandb: WARNING   Violation 4. {'distribution': 'uniform', 'max': -18, 'min': -20} is not valid under any of the given schemas
wandb: WARNING   Violation 5. {'max': -18, 'min': -20, 'distribution': 'uniform'} is not valid under any of the given schemas
wandb: WARNING   Violation 6. {'distribution': 'uniform', 'max': 0.01, 'min': 0} is not valid under any of the given schemas
wandb: WARNING   Violation 7. {'distribution': 'uniform', 'max': -18, 'min': -20} is not valid under any of the given schemas
wandb: WARNING   Violation 8. {'distribution': 'uniform', 'max': -18, 'min': -20} is not valid under any of the given schemas
wandb: WARNING   Violation 9. {'distribution': 'uniform', 'max': 0.02, 'min': 0} is not valid under any of the given schemas
wandb: WARNING   Violation 10. {'max': -6, 'min': -8, 'distribution': 'uniform'} is not valid under any of the given schemas
wandb: WARNING   Violation 11. {'distribution': 'uniform', 'max': -18, 'min': -20} is not valid under any of the given schemas
```

This PR updates the schema to allow integer min/max when the `distribution: uniform` is explicitly specified 

Fixes https://github.com/wandb/client/issues/2317.