### PR TITLE
add py39 to ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,30 @@ jobs:
       - store_test_results:
           path: .
     resource_class: large
+  linux39:
+    machine:
+      image: ubuntu-1604:202007-01
+    steps:
+      - checkout
+      - run:
+          name: Install python
+          command: pyenv install 3.9.0b3
+      - run:
+          name: Load python
+          command: pyenv global 3.9.0b3
+      - run:
+          name: Install dependencies
+          command: pip install -r requirements.dev.txt
+      - run:
+          name: Run Tests
+          command: pytest --cov=./ --cov-report=xml
+      - codecov/upload:
+          file: coverage.xml
+      - store_artifacts:
+          path: prof/
+      - store_test_results:
+          path: .
+    resource_class: large
   linters:
     executor:
       name: python/default

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,12 +43,6 @@ jobs:
       - run:
           name: Run Tests
           command: pytest --cov=./ --cov-report=xml
-      - codecov/upload:
-          file: coverage.xml
-      - store_artifacts:
-          path: prof/
-      - store_test_results:
-          path: .
     resource_class: large
   linters:
     executor:


### PR DESCRIPTION
This PR adds a python 39 version to CI so that tests are run against the versions of anaconda and anaconda2 that are running in prod. 