### PR TITLE
3.9.0b3 -> 3.9.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,10 +33,10 @@ jobs:
       - checkout
       - run:
           name: Install python
-          command: pyenv install 3.9.0b3
+          command: pyenv install 3.9.5
       - run:
           name: Load python
-          command: pyenv global 3.9.0b3
+          command: pyenv global 3.9.5
       - run:
           name: Install dependencies
           command: pip install -r requirements.dev.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
       - checkout
       - run:
           name: Install python
-          command: pyenv install 3.9.5
+          command:   cd /opt/circleci/.pyenv/plugins/python-build/../.. && git pull && cd - && pyenv install 3.9.5
       - run:
           name: Load python
           command: pyenv global 3.9.5


### PR DESCRIPTION
This PR bumps the executor for the linux39 environment on circleci from 3.9.0b3 to 3.9.5 as requested by @vanpelt. 