### PR TITLE
update jsonschema to emit more accurate warnings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,24 @@ jobs:
       - store_test_results:
           path: .
     resource_class: large
+  linux39:
+    machine:
+      image: ubuntu-1604:202007-01
+    steps:
+      - checkout
+      - run:
+          name: Install python
+          command: pyenv install 3.9.0b3
+      - run:
+          name: Load python
+          command: pyenv global 3.9.0b3
+      - run:
+          name: Install dependencies
+          command: pip install -r requirements.dev.txt
+      - run:
+          name: Run Tests
+          command: pytest --cov=./ --cov-report=xml
+    resource_class: large
   linters:
     executor:
       name: python/default
@@ -42,4 +60,5 @@ workflows:
   main:
     jobs:
       - linux38
+      - linux39
       - linters

--- a/config/schema.json
+++ b/config/schema.json
@@ -20,7 +20,8 @@
         "distribution": {
           "enum": [
             "categorical"
-          ]
+          ],
+          "default": "categorical"
         }
       },
       "additionalProperties": false
@@ -38,7 +39,8 @@
         "distribution": {
           "enum": [
             "constant"
-          ]
+          ],
+          "default": "constant"
         }
       },
       "additionalProperties": false
@@ -160,30 +162,56 @@
       "additionalProperties": false
     },
     "param_uniform": {
-      "type": "object",
-      "description": "uniform distribution on real numbers",
-      "required": [
-        "min",
-        "max"
-      ],
-      "properties": {
-        "min": {
-          "description": "float",
-          "type": "number",
-          "format": "float"
+      "anyOf": [
+        {
+          "type": "object",
+          "description": "uniform distribution on real numbers",
+          "required": [
+            "min",
+            "max",
+            "distribution"
+          ],
+          "properties": {
+            "min": {
+              "type": "number"
+            },
+            "max": {
+              "type": "number"
+            },
+            "distribution": {
+              "enum": [
+                "uniform"
+              ]
+            }
+          },
+          "additionalProperties": false
         },
-        "max": {
-          "description": "float",
-          "type": "number",
-          "format": "float"
-        },
-        "distribution": {
-          "enum": [
-            "uniform"
-          ]
+        {
+          "type": "object",
+          "description": "uniform distribution on real numbers",
+          "required": [
+            "min",
+            "max"
+          ],
+          "properties": {
+            "min": {
+              "type": "number",
+              "format": "float"
+            },
+            "max": {
+              "type": "number",
+              "format": "float"
+            },
+            "distribution": {
+              "enum": [
+                "uniform"
+              ],
+              "default": "uniform"
+            }
+          },
+          "additionalProperties": false
         }
-      },
-      "additionalProperties": false
+      ]
     },
     "param_loguniform": {
       "type": "object",
@@ -289,7 +317,8 @@
         "distribution": {
           "enum": [
             "int_uniform"
-          ]
+          ],
+          "default": "int_uniform"
         }
       },
       "additionalProperties": false
@@ -314,6 +343,9 @@
           ]
         }
       },
+      "required": [
+        "distribution"
+      ],
       "additionalProperties": false
     },
     "param_qbeta": {
@@ -342,23 +374,52 @@
           ]
         }
       },
+      "required": [
+        "distribution"
+      ],
       "additionalProperties": false
     },
     "parameter": {
       "anyOf": [
-        {"$ref":  "#/definitions/param_qbeta"},
-        {"$ref":  "#/definitions/param_beta"},
-        {"$ref":  "#/definitions/param_categorical"},
-        {"$ref":  "#/definitions/param_int_uniform"},
-        {"$ref":  "#/definitions/param_uniform"},
-        {"$ref":  "#/definitions/param_lognormal"},
-        {"$ref":  "#/definitions/param_loguniform"},
-        {"$ref":  "#/definitions/param_normal"},
-        {"$ref":  "#/definitions/param_qlognormal"},
-        {"$ref":  "#/definitions/param_qloguniform"},
-        {"$ref":  "#/definitions/param_qnormal"},
-        {"$ref":  "#/definitions/param_quniform"},
-        {"$ref":  "#/definitions/param_single_value"}
+        {
+          "$ref": "#/definitions/param_qbeta"
+        },
+        {
+          "$ref": "#/definitions/param_beta"
+        },
+        {
+          "$ref": "#/definitions/param_categorical"
+        },
+        {
+          "$ref": "#/definitions/param_int_uniform"
+        },
+        {
+          "$ref": "#/definitions/param_uniform"
+        },
+        {
+          "$ref": "#/definitions/param_lognormal"
+        },
+        {
+          "$ref": "#/definitions/param_loguniform"
+        },
+        {
+          "$ref": "#/definitions/param_normal"
+        },
+        {
+          "$ref": "#/definitions/param_qlognormal"
+        },
+        {
+          "$ref": "#/definitions/param_qloguniform"
+        },
+        {
+          "$ref": "#/definitions/param_qnormal"
+        },
+        {
+          "$ref": "#/definitions/param_quniform"
+        },
+        {
+          "$ref": "#/definitions/param_single_value"
+        }
       ]
     },
     "hyperband_stopping": {
@@ -489,7 +550,9 @@
     },
     "early_terminate": {
       "oneOf": [
-        {"$ref":  "#/definitions/hyperband_stopping"}
+        {
+          "$ref": "#/definitions/hyperband_stopping"
+        }
       ]
     },
     "parameters": {
@@ -498,7 +561,10 @@
       "propertyNames": {
         "pattern": "^^[A-Za-z_][A-Za-z0-9_.-]*$"
       },
-      "additionalProperties": {"$ref": "#/definitions/parameter"}
+      "additionalProperties": {
+        "$ref": "#/definitions/parameter"
+      },
+      "minProperties": 1
     }
   }
 }

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -5,14 +5,14 @@ def test_json_type_inference_int_uniform():
     config = {"min": 0, "max": 1}
     param = HyperParameter("int_unif_param", config)
     assert param.type == HyperParameter.INT_UNIFORM
-    assert len(param.config) == 2
+    assert len(param.config) == 3
 
 
 def test_json_type_inference_uniform():
     config = {"min": 0.0, "max": 1.0}
     param = HyperParameter("unif_param", config)
     assert param.type == HyperParameter.UNIFORM
-    assert len(param.config) == 2
+    assert len(param.config) == 3
 
 
 def test_json_type_inference_and_imputation_normal():
@@ -38,7 +38,7 @@ def test_json_type_inference_categorical():
     param = HyperParameter("categorical_param", config)
     assert param.type == HyperParameter.CATEGORICAL
     # TODO(dag): infer distribution key via default
-    assert len(param.config) == 1
+    assert len(param.config) == 2
 
 
 def test_json_type_inference_constant():
@@ -46,7 +46,7 @@ def test_json_type_inference_constant():
     param = HyperParameter("constant_param", config)
     assert param.type == HyperParameter.CONSTANT
     # TODO(dag): infer distribution key via default
-    assert len(param.config) == 1
+    assert len(param.config) == 2
 
 
 def test_json_type_inference_q_normal():

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,6 +1,6 @@
 import pytest
 from jsonschema import ValidationError
-from .. import next_run, stop_runs, SweepConfig
+from .. import next_run, stop_runs
 from ..config import SweepConfig, schema_violations_from_proposed_config
 from ..bayes_search import bayes_search_next_run
 from ..grid_search import grid_search_next_run
@@ -61,6 +61,7 @@ def test_minmax_type_inference():
 
     violations = schema_violations_from_proposed_config(schema)
     assert len(violations) == 1
+
 
 @pytest.mark.parametrize("controller_type", ["cloud", "local", "invalid"])
 def test_controller(controller_type):


### PR DESCRIPTION
When a user passes integermin/max values for a sweep parameter explicitly declared with distribution: "uniform" the backend throws warnings like:

```
wandb: WARNING To avoid this, please fix the sweep config schema violations below:
wandb: WARNING   Violation 1. {'distribution': 'uniform', 'max': -18, 'min': -20} is not valid under any of the given schemas
wandb: WARNING   Violation 2. {'distribution': 'uniform', 'max': 0.01, 'min': 0} is not valid under any of the given schemas
wandb: WARNING   Violation 3. {'distribution': 'uniform', 'max': 0.05, 'min': 0} is not valid under any of the given schemas
wandb: WARNING   Violation 4. {'distribution': 'uniform', 'max': -18, 'min': -20} is not valid under any of the given schemas
wandb: WARNING   Violation 5. {'max': -18, 'min': -20, 'distribution': 'uniform'} is not valid under any of the given schemas
wandb: WARNING   Violation 6. {'distribution': 'uniform', 'max': 0.01, 'min': 0} is not valid under any of the given schemas
wandb: WARNING   Violation 7. {'distribution': 'uniform', 'max': -18, 'min': -20} is not valid under any of the given schemas
wandb: WARNING   Violation 8. {'distribution': 'uniform', 'max': -18, 'min': -20} is not valid under any of the given schemas
wandb: WARNING   Violation 9. {'distribution': 'uniform', 'max': 0.02, 'min': 0} is not valid under any of the given schemas
wandb: WARNING   Violation 10. {'max': -6, 'min': -8, 'distribution': 'uniform'} is not valid under any of the given schemas
wandb: WARNING   Violation 11. {'distribution': 'uniform', 'max': -18, 'min': -20} is not valid under any of the given schemas
```

This PR updates the schema to allow integer min/max when the distribution: uniform is explicitly specified

Unrelated small change: it also requires that a valid sweepconfig have at least 1 parameter. 

With wandb/client#2337, fixes wandb/client#2317.