### PR TITLE
Fix differences between anaconda1 and anaconda2: bayes_search should return nan instead of none

### DIFF
--- a/bayes_search.py
+++ b/bayes_search.py
@@ -159,7 +159,7 @@ def next_sample(
     num_points_to_try: integer = 1000,
     opt_func: str = "expected_improvement",
     test_X: Optional[npt.ArrayLike] = None,
-) -> Tuple[npt.ArrayLike, floating, floating, Optional[floating], Optional[floating]]:
+) -> Tuple[npt.ArrayLike, floating, floating, floating, floating]:
     """Calculates the best next sample to look at via bayesian optimization.
 
     Args:
@@ -242,8 +242,8 @@ def next_sample(
             X,
             1.0,
             prediction,
-            None,
-            None,
+            np.nan,
+            np.nan,
         )
 
     # build the acquisition function


### PR DESCRIPTION
Seen in GCP shadow logs:

```
config: "{"method":"bayes","metric":{"goal":"minimize","name":"loss"},"parameters":{"v1":{"min":1,"max":10},"v2":{"min":1,"max":10}},"program":"train.py"}"
ctx: {0}
diff: "  strings.Join({
  	`{"args":{"v1":{"value":4},"v2":{"value":9}},"logs":["expected_im`,
  	"provement: ",
- 	"None",
+ 	"nan",
  	`","predicted_value: 0.0","predicted_value_std_dev: `,
- 	"None",
+ 	"nan",
  	"\",\"success_probability: 1.0\"]}\n",
  }, "")
"
mismatchIn: "NextArgs"
runs: [0]
}
```

this fixes that bug, causing `bayes_search` to return nan instead of None when it doesn't have a stddev or an expected improvement due to too few runs 