### PR TITLE
make eta minimum exclusive, otherwise hyperband does not remove runs

### DIFF
--- a/config/schema.json
+++ b/config/schema.json
@@ -466,7 +466,7 @@
         "eta": {
           "type": "number",
           "description": "At every eta^n steps, hyperband continues running the top 1/eta runs and stops all other runs",
-          "minimum": 1,
+          "exclusiveMinimum": 1,
           "default": 3
         }
       }


### PR DESCRIPTION
Fixes this sentry issue: 

https://sentry.io/organizations/weights-biases/issues/2495629715/?project=5812400&query=is%3Aunresolved

From the hyperband paper, each round of hyperband retains 1/η configurations for a total of log_η(n) + 1
rounds of elimination with n configurations of hyperparameters.

If eta is exactly 1 then there will be no stopping at any iteration and an infinite number of rounds of hyperband. 

This PR fixes this by making the requirement on eta exclude 1 rather than being `>=` 1. 