### PR TITLE
fix discrepancies between anaconda1 and anaconda2: disallow zero-length categorical parameter value lists

### DIFF
--- a/config/schema.json
+++ b/config/schema.json
@@ -15,7 +15,8 @@
         "values": {
           "type": "array",
           "description": "Discrete values",
-          "uniqueItems": true
+          "uniqueItems": true,
+          "minItems": 1
         },
         "distribution": {
           "enum": [

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,3 +1,5 @@
+import pytest
+import jsonschema
 from ..params import HyperParameter
 
 
@@ -82,3 +84,9 @@ def test_validate_does_not_modify_passed_config():
     config_save = config.copy()
     _ = HyperParameter("normal_test", config)
     assert config == config_save
+
+
+def test_categorical_hyperparameter_no_values():
+    config = {"values": []}
+    with pytest.raises(jsonschema.ValidationError):
+        HyperParameter("invalid_test", config)


### PR DESCRIPTION
Fixes this issue in sentry:

https://sentry.io/organizations/weights-biases/issues/2498428644/?project=5812400&referrer=slack

<img width="1149" alt="Screen Shot 2021-07-06 at 10 49 49 PM" src="https://user-images.githubusercontent.com/2769632/124706652-814d4c80-deac-11eb-9782-ffa9da82416c.png">

Caused by categorical parameters with no listed values (`flag` below):

<img width="479" alt="Screen Shot 2021-07-06 at 10 49 55 PM" src="https://user-images.githubusercontent.com/2769632/124706683-9033ff00-deac-11eb-9eff-3be42533daff.png">

This PR updates the schema to require that categorical parameters have at least one value and adds a unit test 