### PR TITLE
fix discrepancies between anaconda1 and anaconda2: require at least 1 searchable parameter for bayes search

### DIFF
--- a/bayes_search.py
+++ b/bayes_search.py
@@ -347,6 +347,9 @@ def bayes_search_next_run(
     worst_func = min if goal == "maximize" else max
     params = HyperParameterSet.from_config(config["parameters"])
 
+    if len(params.searchable_params) == 0:
+        raise ValueError("Need at least one searchable parameter for bayes search.")
+
     sample_X = []
     current_X = []
     y = []


### PR DESCRIPTION
Fixes this error seen in sentry and support:

https://sentry.io/organizations/weights-biases/issues/2510483895/?project=5812400&referrer=slack

A user passed a config file that had all constant parameters. When they attempted to run a bayes search sweep there was an uncaught exception complaining that the gaussian process was attemping to be trained on a zero-dimensional parameter space. This PR requires that there be at least one parameter that can vary when attempting to run a grid search. 