### PR TITLE
make anaconda2 more reliable: require that sweep config be parsable as a json object

### DIFF
--- a/config/cfg.py
+++ b/config/cfg.py
@@ -15,6 +15,9 @@ def schema_violations_from_proposed_config(config: Dict) -> List[str]:
     for error in validator.iter_errors(config):
         schema_violation_messages.append(f"{error.message}")
 
+    if not isinstance(config, dict):
+        raise ValueError("Sweep config must be parsable as a JSON object.")
+
     # validate min/max - this cannot be done with jsonschema
     # because it does not support comparing values within
     # a json document. so we do it manually here:

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -76,3 +76,9 @@ def test_controller(controller_type):
     else:
         with pytest.raises(ValidationError):
             SweepConfig(schema)
+
+
+def test_invalid_config():
+    config = "this is a totally invalid config"
+    with pytest.raises(ValueError):
+        SweepConfig(config)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -81,4 +81,4 @@ def test_controller(controller_type):
 def test_invalid_config():
     config = "this is a totally invalid config"
     with pytest.raises(ValueError):
-        SweepConfig(config)
+        schema_violations_from_proposed_config(config)


### PR DESCRIPTION
Fixes this error from sentry:

https://sentry.io/organizations/weights-biases/issues/2509315018/?project=5812400&referrer=slack

This was raised because a user passed a sweep config that was:

`"wandb sweep --update dscnas/sdfs/cudghvjr sweep.yaml"`

which is not parsable as a JSON string. 

This PR does not perform min/max validation on a passed config unless the object is parsable as a json object. 
