### PR TITLE
Impute missing parameter values using jsonschema defaults

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,6 +1,11 @@
 # -*- coding: utf-8 -*-
 """Sweep config interface."""
 from .cfg import SweepConfig, schema_violations_from_proposed_config
-from .schema import fill_schema
+from .schema import fill_schema, fill_parameter
 
-__all__ = ["SweepConfig", "schema_violations_from_proposed_config", "fill_schema"]
+__all__ = [
+    "SweepConfig",
+    "schema_violations_from_proposed_config",
+    "fill_schema",
+    "fill_parameter",
+]

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 """Sweep config interface."""
 from .cfg import SweepConfig, schema_violations_from_proposed_config
+from .schema import fill_schema
 
-__all__ = [
-    "SweepConfig",
-    "schema_violations_from_proposed_config",
-]
+__all__ = ["SweepConfig", "schema_violations_from_proposed_config", "fill_schema"]

--- a/config/cfg.py
+++ b/config/cfg.py
@@ -32,8 +32,6 @@ def schema_violations_from_proposed_config(config: Dict) -> List[str]:
 
 class SweepConfig(dict):
     def __init__(self, d: Dict):
-        super(SweepConfig, self).__init__(deepcopy(d))
-
         if not isinstance(d, SweepConfig):
             # ensure the data conform to the schema
             schema_violation_messages = schema_violations_from_proposed_config(d)
@@ -41,6 +39,8 @@ class SweepConfig(dict):
             if len(schema_violation_messages) > 0:
                 err_msg = "\n".join(schema_violation_messages)
                 raise jsonschema.ValidationError(err_msg)
+
+        super(SweepConfig, self).__init__(deepcopy(d))
 
     def __str__(self) -> str:
         return yaml.safe_dump(self)

--- a/config/cfg.py
+++ b/config/cfg.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Union, Dict, List
 
 import jsonschema
-from .schema import validator
+from .schema import validator, fill_schema
 from copy import deepcopy
 
 
@@ -40,7 +40,9 @@ class SweepConfig(dict):
                 err_msg = "\n".join(schema_violation_messages)
                 raise jsonschema.ValidationError(err_msg)
 
-        super(SweepConfig, self).__init__(deepcopy(d))
+        copied_config = deepcopy(d)
+        filled_config = fill_schema(copied_config)
+        super(SweepConfig, self).__init__(filled_config)
 
     def __str__(self) -> str:
         return yaml.safe_dump(self)

--- a/config/cfg.py
+++ b/config/cfg.py
@@ -7,6 +7,7 @@ from typing import Union, Dict, List
 
 import jsonschema
 from .schema import validator
+from copy import deepcopy
 
 
 def schema_violations_from_proposed_config(config: Dict) -> List[str]:
@@ -31,7 +32,7 @@ def schema_violations_from_proposed_config(config: Dict) -> List[str]:
 
 class SweepConfig(dict):
     def __init__(self, d: Dict):
-        super(SweepConfig, self).__init__(d)
+        super(SweepConfig, self).__init__(deepcopy(d))
 
         if not isinstance(d, SweepConfig):
             # ensure the data conform to the schema

--- a/config/schema.json
+++ b/config/schema.json
@@ -20,7 +20,8 @@
         "distribution": {
           "enum": [
             "categorical"
-          ]
+          ],
+          "default": "categorical"
         }
       },
       "additionalProperties": false
@@ -342,7 +343,9 @@
           ]
         }
       },
-      "required": ["distribution"],
+      "required": [
+        "distribution"
+      ],
       "additionalProperties": false
     },
     "param_qbeta": {
@@ -371,7 +374,9 @@
           ]
         }
       },
-      "required": ["distribution"],
+      "required": [
+        "distribution"
+      ],
       "additionalProperties": false
     },
     "parameter": {

--- a/config/schema.json
+++ b/config/schema.json
@@ -199,6 +199,12 @@
             "max": {
               "type": "number",
               "format": "float"
+            },
+            "distribution": {
+              "enum": [
+                "uniform"
+              ],
+              "default": "uniform"
             }
           },
           "additionalProperties": false

--- a/config/schema.json
+++ b/config/schema.json
@@ -559,7 +559,7 @@
       "additionalProperties": {
         "$ref": "#/definitions/parameter"
       },
-      "minLength": 1
+      "minProperties": 1
     }
   }
 }

--- a/config/schema.json
+++ b/config/schema.json
@@ -558,7 +558,8 @@
       },
       "additionalProperties": {
         "$ref": "#/definitions/parameter"
-      }
+      },
+      "minLength": 1
     }
   }
 }

--- a/config/schema.json
+++ b/config/schema.json
@@ -38,7 +38,8 @@
         "distribution": {
           "enum": [
             "constant"
-          ]
+          ],
+          "default": "constant"
         }
       },
       "additionalProperties": false
@@ -341,6 +342,7 @@
           ]
         }
       },
+      "required": ["distribution"],
       "additionalProperties": false
     },
     "param_qbeta": {
@@ -369,6 +371,7 @@
           ]
         }
       },
+      "required": ["distribution"],
       "additionalProperties": false
     },
     "parameter": {

--- a/config/schema.json
+++ b/config/schema.json
@@ -160,30 +160,50 @@
       "additionalProperties": false
     },
     "param_uniform": {
-      "type": "object",
-      "description": "uniform distribution on real numbers",
-      "required": [
-        "min",
-        "max"
-      ],
-      "properties": {
-        "min": {
-          "description": "float",
-          "type": "number",
-          "format": "float"
+      "anyOf": [
+        {
+          "type": "object",
+          "description": "uniform distribution on real numbers",
+          "required": [
+            "min",
+            "max",
+            "distribution"
+          ],
+          "properties": {
+            "min": {
+              "type": "number"
+            },
+            "max": {
+              "type": "number"
+            },
+            "distribution": {
+              "enum": [
+                "uniform"
+              ]
+            }
+          },
+          "additionalProperties": false
         },
-        "max": {
-          "description": "float",
-          "type": "number",
-          "format": "float"
-        },
-        "distribution": {
-          "enum": [
-            "uniform"
-          ]
+        {
+          "type": "object",
+          "description": "uniform distribution on real numbers",
+          "required": [
+            "min",
+            "max"
+          ],
+          "properties": {
+            "min": {
+              "type": "number",
+              "format": "float"
+            },
+            "max": {
+              "type": "number",
+              "format": "float"
+            }
+          },
+          "additionalProperties": false
         }
-      },
-      "additionalProperties": false
+      ]
     },
     "param_loguniform": {
       "type": "object",
@@ -346,19 +366,45 @@
     },
     "parameter": {
       "anyOf": [
-        {"$ref":  "#/definitions/param_qbeta"},
-        {"$ref":  "#/definitions/param_beta"},
-        {"$ref":  "#/definitions/param_categorical"},
-        {"$ref":  "#/definitions/param_int_uniform"},
-        {"$ref":  "#/definitions/param_uniform"},
-        {"$ref":  "#/definitions/param_lognormal"},
-        {"$ref":  "#/definitions/param_loguniform"},
-        {"$ref":  "#/definitions/param_normal"},
-        {"$ref":  "#/definitions/param_qlognormal"},
-        {"$ref":  "#/definitions/param_qloguniform"},
-        {"$ref":  "#/definitions/param_qnormal"},
-        {"$ref":  "#/definitions/param_quniform"},
-        {"$ref":  "#/definitions/param_single_value"}
+        {
+          "$ref": "#/definitions/param_qbeta"
+        },
+        {
+          "$ref": "#/definitions/param_beta"
+        },
+        {
+          "$ref": "#/definitions/param_categorical"
+        },
+        {
+          "$ref": "#/definitions/param_int_uniform"
+        },
+        {
+          "$ref": "#/definitions/param_uniform"
+        },
+        {
+          "$ref": "#/definitions/param_lognormal"
+        },
+        {
+          "$ref": "#/definitions/param_loguniform"
+        },
+        {
+          "$ref": "#/definitions/param_normal"
+        },
+        {
+          "$ref": "#/definitions/param_qlognormal"
+        },
+        {
+          "$ref": "#/definitions/param_qloguniform"
+        },
+        {
+          "$ref": "#/definitions/param_qnormal"
+        },
+        {
+          "$ref": "#/definitions/param_quniform"
+        },
+        {
+          "$ref": "#/definitions/param_single_value"
+        }
       ]
     },
     "hyperband_stopping": {
@@ -489,7 +535,9 @@
     },
     "early_terminate": {
       "oneOf": [
-        {"$ref":  "#/definitions/hyperband_stopping"}
+        {
+          "$ref": "#/definitions/hyperband_stopping"
+        }
       ]
     },
     "parameters": {
@@ -498,7 +546,9 @@
       "propertyNames": {
         "pattern": "^^[A-Za-z_][A-Za-z0-9_.-]*$"
       },
-      "additionalProperties": {"$ref": "#/definitions/parameter"}
+      "additionalProperties": {
+        "$ref": "#/definitions/parameter"
+      }
     }
   }
 }

--- a/config/schema.json
+++ b/config/schema.json
@@ -315,7 +315,8 @@
         "distribution": {
           "enum": [
             "int_uniform"
-          ]
+          ],
+          "default": "int_uniform"
         }
       },
       "additionalProperties": false

--- a/config/schema.py
+++ b/config/schema.py
@@ -96,10 +96,14 @@ def fill_parameter(config: Dict) -> Optional[Tuple[str, Dict]]:
 
 
 def fill_schema(d: Dict) -> Dict:
-    from . import SweepConfig
+    from . import schema_violations_from_proposed_config
 
     # check that the schema is valid
-    validated = SweepConfig(d)
+    violations = schema_violations_from_proposed_config(d)
+    if len(violations) != 0:
+        raise jsonschema.ValidationError("\n".join(violations))
+
+    validated = deepcopy(d)
 
     # update the parameters
     filled = {}

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -5,14 +5,18 @@ def test_json_type_inference_int_uniform():
     config = {"min": 0, "max": 1}
     param = HyperParameter("int_unif_param", config)
     assert param.type == HyperParameter.INT_UNIFORM
-    assert len(param.config) == 2
+
+    # len is 3 because distribution key is inferred via default
+    assert len(param.config) == 3
 
 
 def test_json_type_inference_uniform():
     config = {"min": 0.0, "max": 1.0}
     param = HyperParameter("unif_param", config)
     assert param.type == HyperParameter.UNIFORM
-    assert len(param.config) == 2
+
+    # len is 3 because distribution key is inferred via default
+    assert len(param.config) == 3
 
 
 def test_json_type_inference_and_imputation_normal():
@@ -37,16 +41,17 @@ def test_json_type_inference_categorical():
     config = {"values": [1, 2, 3]}
     param = HyperParameter("categorical_param", config)
     assert param.type == HyperParameter.CATEGORICAL
-    # TODO(dag): infer distribution key via default
-    assert len(param.config) == 1
+    # len is 2 because distribution key is inferred via default
+    assert len(param.config) == 2
 
 
 def test_json_type_inference_constant():
     config = {"value": "abcd"}
     param = HyperParameter("constant_param", config)
     assert param.type == HyperParameter.CONSTANT
-    # TODO(dag): infer distribution key via default
-    assert len(param.config) == 1
+
+    # len is 2 because distribution key is inferred via default
+    assert len(param.config) == 2
 
 
 def test_json_type_inference_q_normal():

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,6 +1,7 @@
 import pytest
 import jsonschema
 from ..params import HyperParameter
+from ..config import SweepConfig
 
 
 def test_json_type_inference_int_uniform():
@@ -103,3 +104,37 @@ def test_uniform_with_integer_min_max():
     config = {"distribution": "uniform", "min": 0, "max": 1}  # integers
     unif_param = HyperParameter("uniform_param", config)  # this should not raise
     assert unif_param.type == HyperParameter.UNIFORM
+
+
+def test_hyperband_missing_eta_imputed():
+    # sentry https://sentry.io/organizations/weights-biases/issues/2500192925/?referrer=slack
+    config = {
+        "command": [
+            "${env}",
+            "${interpreter}",
+            "${program}",
+            "sweep",
+            "2dconv_lstm.stat.ac",
+            "--dataset",
+            "deam",
+            "--temp_folder",
+            "a_deam",
+            "--batch-size",
+        ],
+        "early_terminate": {"min_iter": 3, "type": "hyperband"},
+        "method": "random",
+        "metric": {"goal": "minimize", "name": "val/loss"},
+        "name": "AC-2DConvLSTM-Stat-DEAM",
+        "parameters": {
+            "dropout": {"values": ["0.15", "0.2", "0.25", "0.3", "0.4", "0.5"]},
+            "lr": {"values": ["0.001", "0.005", "0.01"]},
+            "momentum": {"values": ["0.8", "0.9", "0.95"]},
+            "n_fft": {"value": 1024},
+            "n_mels": {"value": 128},
+        },
+        "program": "exec.py",
+        "project": "mer",
+    }
+
+    sc = SweepConfig(config)
+    assert sc["early_terminate"]["eta"] == 3

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -82,3 +82,11 @@ def test_validate_does_not_modify_passed_config():
     config_save = config.copy()
     _ = HyperParameter("normal_test", config)
     assert config == config_save
+
+
+def test_uniform_with_integer_min_max():
+    # CLI-975
+    # https://github.com/wandb/sweeps/pull/16
+    config = {"distribution": "uniform", "min": 0, "max": 1}  # integers
+    unif_param = HyperParameter("uniform_param", config)  # this should not raise
+    assert unif_param.type == HyperParameter.UNIFORM


### PR DESCRIPTION
I have been seeing errors go by on sentry like:

https://sentry.io/organizations/weights-biases/issues/2500192925/?referrer=slack

This happens when we try to access parameters that have a default value, but we haven't filled that default.

This PR fills default values for missing parameters using jsonschema. 

Testing:

Added a bunch of unit tests.