### PR TITLE
fix user-facing key error by adding an if guard around parameters

### DIFF
--- a/config/cfg.py
+++ b/config/cfg.py
@@ -22,14 +22,15 @@ def schema_violations_from_proposed_config(config: Dict) -> List[str]:
     # validate min/max - this cannot be done with jsonschema
     # because it does not support comparing values within
     # a json document. so we do it manually here:
-    for parameter_name, parameter_dict in config["parameters"].items():
-        if "min" in parameter_dict and "max" in parameter_dict:
-            # this comparison is type safe because the jsonschema enforces type uniformity
-            if parameter_dict["min"] >= parameter_dict["max"]:
-                schema_violation_messages.append(
-                    f'{parameter_name}: min {parameter_dict["min"]} is not '
-                    f'less than max {parameter_dict["max"]}'
-                )
+    if "parameters" in config:
+        for parameter_name, parameter_dict in config["parameters"].items():
+            if "min" in parameter_dict and "max" in parameter_dict:
+                # this comparison is type safe because the jsonschema enforces type uniformity
+                if parameter_dict["min"] >= parameter_dict["max"]:
+                    schema_violation_messages.append(
+                        f'{parameter_name}: min {parameter_dict["min"]} is not '
+                        f'less than max {parameter_dict["max"]}'
+                    )
     return schema_violation_messages
 
 


### PR DESCRIPTION
Fixes this error seen in sentry:

https://sentry.io/organizations/weights-biases/issues/2461042074/?project=5812400&query=is%3Aunresolved&statsPeriod=90d

Sometimes users provide sweep configs without a parameters section. This causes the min/max python validation logic to raise a user facing keyerror. This PR fixes this by adding an if guard around that dict access. If there is no parameters section, no need to run the min/max checks, since these can only be done on parameters anyway. 