### PR TITLE
make error message  for "could not find value" more informative

### DIFF
--- a/params.py
+++ b/params.py
@@ -81,7 +81,10 @@ class HyperParameter:
             if value == test_value:
                 return ii
 
-        raise ValueError("Couldn't find {}".format(value))
+        raise ValueError(
+            f"{value} is not a permitted value of the categorical hyperparameter {self.name} "
+            f"in the current sweep."
+        )
 
     def cdf(self, x: ArrayLike) -> ArrayLike:
         """Cumulative distribution function (CDF).

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -130,12 +130,13 @@ def test_invalid_early_stopping():
 def test_invalid_run_parameter():
     config = {
         "method": "bayes",
+        "metric": {"name": "loss", "goal": "minimize"},
         "parameters": {
             "v1": {"values": ["a", "b", "c"]},
         },
     }
 
-    runs = [SweepRun(config={"v1": {"value": "d"}})]
+    runs = [SweepRun(config={"v1": {"value": "d"}}, summary_metrics={"loss": 5.0})]
 
     with pytest.raises(ValueError):
         next_run(config, runs, validate=False)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,6 +1,6 @@
 import pytest
 from jsonschema import ValidationError
-from .. import next_run, stop_runs
+from .. import next_run, stop_runs, SweepRun
 from ..config import SweepConfig, schema_violations_from_proposed_config
 from ..bayes_search import bayes_search_next_runs
 from ..grid_search import grid_search_next_runs
@@ -125,3 +125,17 @@ def test_invalid_early_stopping():
 
     to_stop = stop_runs(invalid_schema, [], validate=False)
     assert len(to_stop) == 0
+
+
+def test_invalid_run_parameter():
+    config = {
+        "method": "bayes",
+        "parameters": {
+            "v1": {"values": ["a", "b", "c"]},
+        },
+    }
+
+    runs = [SweepRun(config={"v1": {"value": "d"}})]
+
+    with pytest.raises(ValueError):
+        next_run(config, runs, validate=False)


### PR DESCRIPTION
Augments an existing error message (also present in anaconda1 under the same conditions) with a bit more information that may be useful to the user. 