### PR TITLE
Allow mutable python objects as parameter values in grid search by directly hashing yaml representation

### DIFF
--- a/tests/test_grid_search.py
+++ b/tests/test_grid_search.py
@@ -153,5 +153,5 @@ def test_grid_search_dict_val_is_propagated(randomize):
 
     hashes = kernel_for_grid_search_tests([], config_const, randomize=randomize)
 
-    # assert that only 9 hyperparameter combos are iterated over, as there is one duplicate in v2
+    # assert that only 9 hyperparameter combos are iterated over, as there are 2 duplicates in v2
     assert len(hashes) == 3 * 3

--- a/tests/test_grid_search.py
+++ b/tests/test_grid_search.py
@@ -15,7 +15,7 @@ def kernel_for_grid_search_tests(
     """This kernel assumes that sweep config has two categorical parameters
     named v1 and v2."""
 
-    answers = list(
+    answer_hashes = list(
         set(
             itertools.product(
                 [yaml_hash(v) for v in config["parameters"]["v1"]["values"]],
@@ -23,7 +23,7 @@ def kernel_for_grid_search_tests(
             )
         )
     )
-    suggested_parameters = [
+    suggested_parameter_hashes = [
         (
             yaml_hash(run.config["v1"]["value"]),
             yaml_hash(run.config["v2"]["value"]),
@@ -38,18 +38,18 @@ def kernel_for_grid_search_tests(
         assert suggestion.search_info is None
         assert suggestion.state == RunState.pending
         runs.append(suggestion)
-        suggested_parameters.append(
+        suggested_parameter_hashes.append(
             (
                 yaml_hash(suggestion.config["v1"]["value"]),
                 yaml_hash(suggestion.config["v2"]["value"]),
             )
         )
 
-    assert len(answers) == len(suggested_parameters)
-    for key in suggested_parameters:
-        assert key in answers
+    assert len(answer_hashes) == len(suggested_parameter_hashes)
+    for key in suggested_parameter_hashes:
+        assert key in answer_hashes
 
-    return suggested_parameters
+    return suggested_parameter_hashes
 
 
 @pytest.mark.parametrize("randomize", [True, False])

--- a/tests/test_grid_search.py
+++ b/tests/test_grid_search.py
@@ -139,7 +139,13 @@ def test_grid_search_dict_val_is_propagated(randomize):
             "parameters": {
                 "v1": {"values": ["a", "b", "c'"]},
                 "v2": {
-                    "values": [{"a": "b"}, {"c": "d"}, {"e": {"f": "g"}}, {"a": "b"}]
+                    "values": [
+                        {"a": "b"},
+                        {"c": "d", "b": "g"},
+                        {"e": {"f": "g"}},
+                        {"a": "b"},
+                        {"b": "g", "c": "d"},
+                    ]
                 },
             },
         }

--- a/tests/test_grid_search.py
+++ b/tests/test_grid_search.py
@@ -127,3 +127,18 @@ def test_grid_search_constant_val_is_propagated():
     run = next_run(config_const, runs)
     assert "v1" in run.config
     assert "v2" in run.config
+
+
+@pytest.mark.parametrize("randomize", [True, False])
+def test_grid_search_dict_val_is_propagated(randomize):
+    config_const = SweepConfig(
+        {
+            "method": "grid",
+            "parameters": {
+                "v1": {"values": ["a", "b", "c'"]},
+                "v2": {"values": [{"a": "b"}, {"c": "d"}, {"e": {"f": "g"}}]},
+            },
+        }
+    )
+
+    kernel_for_grid_search_tests([], config_const, randomize=randomize)

--- a/tests/test_grid_search.py
+++ b/tests/test_grid_search.py
@@ -1,7 +1,7 @@
 import pytest
 import itertools
 
-from typing import List, Tuple
+from typing import List, Sequence, Tuple
 from ..run import RunState, SweepRun, next_run
 from ..config import SweepConfig
 from ..grid_search import yaml_hash
@@ -11,7 +11,7 @@ def kernel_for_grid_search_tests(
     runs: List[SweepRun],
     config: SweepConfig,
     randomize: bool,
-) -> List[Tuple[str]]:
+) -> Sequence[Tuple]:
     """This kernel assumes that sweep config has two categorical parameters
     named v1 and v2."""
 

--- a/tests/test_grid_search.py
+++ b/tests/test_grid_search.py
@@ -4,7 +4,7 @@ import itertools
 from typing import List
 from ..run import RunState, SweepRun, next_run
 from ..config import SweepConfig
-from ..grid_search import list_to_tuple
+from ..grid_search import yaml_hash
 
 
 def kernel_for_grid_search_tests(
@@ -18,15 +18,15 @@ def kernel_for_grid_search_tests(
     answers = list(
         set(
             itertools.product(
-                list_to_tuple(config["parameters"]["v1"]["values"]),
-                list_to_tuple(config["parameters"]["v2"]["values"]),
+                [yaml_hash(v) for v in config["parameters"]["v1"]["values"]],
+                [yaml_hash(v) for v in config["parameters"]["v2"]["values"]],
             )
         )
     )
     suggested_parameters = [
         (
-            list_to_tuple(run.config["v1"]["value"]),
-            list_to_tuple(run.config["v2"]["value"]),
+            yaml_hash(run.config["v1"]["value"]),
+            yaml_hash(run.config["v2"]["value"]),
         )
         for run in runs
     ]
@@ -40,8 +40,8 @@ def kernel_for_grid_search_tests(
         runs.append(suggestion)
         suggested_parameters.append(
             (
-                list_to_tuple(suggestion.config["v1"]["value"]),
-                list_to_tuple(suggestion.config["v2"]["value"]),
+                yaml_hash(suggestion.config["v1"]["value"]),
+                yaml_hash(suggestion.config["v2"]["value"]),
             )
         )
 


### PR DESCRIPTION
This PR fixes this issue raised by @savvaki, https://github.com/wandb/client/pull/2557#issuecomment-901696670, using hashes of arbitrary python objects' yaml representations. Keeping this as a draft because there is some risk in deploying this; need to think more about the YAML hashes and whether they are safe. Will open a parallel PR that restores the old grid search behavior from anaconda1. The benefit of using this scheme is that it scales better than the anaconda1 implementation with the number of runs in the sweep. Will run this in shadow mode for a bit.

