### PR TITLE
Revert grid search logic to anaconda1 logic

### DIFF
--- a/tests/test_grid_search.py
+++ b/tests/test_grid_search.py
@@ -178,3 +178,41 @@ def test_grid_search_constant_val_is_propagated():
     run = next_run(config_const, runs)
     assert "v1" in run.config
     assert "v2" in run.config
+
+
+@pytest.mark.parametrize("randomize", [True, False])
+def test_grid_search_dict_val_is_propagated(randomize):
+    config_const = SweepConfig(
+        {
+            "method": "grid",
+            "parameters": {
+                "v1": {"values": ["a", "b", "c'"]},
+                "v2": {
+                    "values": [
+                        {"a": "b"},
+                        {"c": "d", "b": "g"},
+                        {"e": {"f": "g"}},
+                        {"a": "b"},
+                        {"b": "g", "c": "d"},
+                    ]
+                },
+            },
+        }
+    )
+
+    kernel_for_grid_search_tests(
+        [],
+        config_const,
+        randomize=randomize,
+        answers=[
+            ("a", {"a": "b"}),
+            ("a", {"c": "d", "b": "g"}),
+            ("a", {"e": {"f": "g"}}),
+            ("b", {"a": "b"}),
+            ("b", {"c": "d", "b": "g"}),
+            ("b", {"e": {"f": "g"}}),
+            ("c'", {"a": "b"}),
+            ("c'", {"c": "d", "b": "g"}),
+            ("c'", {"e": {"f": "g"}}),
+        ],
+    )


### PR DESCRIPTION
This PR vendors the grid search logic to the anaconda1 logic (with a few very minor modifications to conform to wandb/sweeps contracts). 

I am doing this because there have been two issues that cropped up with the anaconda2 rollout so far that were both related to grid search sweeps. The reason this has been happening is because my mismatch comparison in the cloud shadow logs was very noisy for grid searches, so I didn't catch everything.

As a precaution I am reverting the grid search logic back to the anaconda1 logic. I also added a test specifically to address the issue raised by @savvaki. 

This should return the grid search behavior back to what it was before the anaconda2 rollout. The downside of this is that we lose the speedup provided by the hash lookups of sweep parameters. I have a PR open (#41) that attempts to keep this speedup but fix issues related to hashing of mutable python objects like dicts and lists.

That PR should run in shadow mode behind the anaconda1 grid search logic running as primary.