### PR TITLE
[WB-6505] Ensure that all sweep configs have a parameters section

### DIFF
--- a/run.py
+++ b/run.py
@@ -161,7 +161,7 @@ def next_run(
 
     if not (
         isinstance(sweep_config["parameters"], dict)
-        and len(sweep_config["parameters"] > 0)
+        and len(sweep_config["parameters"]) > 0
     ):
         raise ValueError(
             "Parameters section of sweep config must be a dict of at least length 1"

--- a/run.py
+++ b/run.py
@@ -154,7 +154,18 @@ def next_run(
         sweep_config = SweepConfig(sweep_config)
 
     if "method" not in sweep_config:
-        raise ValueError("Sweep config must contain metric section")
+        raise ValueError("Sweep config must contain method section")
+
+    if "parameters" not in sweep_config:
+        raise ValueError("Sweep config must contain parameters section")
+
+    if not (
+        isinstance(sweep_config["parameters"], dict)
+        and len(sweep_config["parameters"] > 0)
+    ):
+        raise ValueError(
+            "Parameters section of sweep config must be a dict of at least length 1"
+        )
 
     method = sweep_config["method"]
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -52,6 +52,11 @@ def test_validation_not_enough_params():
     with pytest.raises(ValueError):
         next_run(schema, [])
 
+    del schema["parameters"]
+    # test that this is rejected at the next_run stage
+    with pytest.raises(ValueError):
+        next_run(schema, [])
+
 
 def test_minmax_type_inference():
     schema = {

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -48,6 +48,10 @@ def test_validation_not_enough_params():
     result = schema_violations_from_proposed_config(schema)
     assert len(result) == 1
 
+    # test that this is rejected at the next_run stage
+    with pytest.raises(ValueError):
+        next_run(schema, [])
+
 
 def test_minmax_type_inference():
     schema = {


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-6505

This PR enforces that all sweep configs have a parameters section with at least 1 parameter, fixing this sentry issue:

https://sentry.io/organizations/weights-biases/issues/2592965479/?referrer=jira_integration

Added a unit test. 