### PR TITLE
Add changes needed for supporting run queue backed sweeps

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,2 +1,2 @@
-from .run import next_run, stop_runs, SweepRun, RunState  # noqa
+from .run import next_run, next_runs, stop_runs, SweepRun, RunState  # noqa
 from .config import SweepConfig, schema_violations_from_proposed_config  # noqa

--- a/bayes_search.py
+++ b/bayes_search.py
@@ -365,7 +365,12 @@ def _construct_gp_data(
                 metric = worst_metric  # default
             y.append(metric)
             sample_X.append(X_norm)
-        elif run.state in [RunState.running, RunState.preempting, RunState.preempted]:
+        elif run.state in [
+            RunState.running,
+            RunState.preempting,
+            RunState.preempted,
+            RunState.pending,
+        ]:
             # run is in progress
             # we wont use the metric, but we should pass it into our optimizer to
             # account for the fact that it is running
@@ -462,3 +467,19 @@ def bayes_search_next_run(
         "expected_improvement": suggested_X_expected_improvement,
     }
     return SweepRun(config=ret_dict, search_info=info)
+
+
+def bayes_search_next_runs(
+    runs: List[SweepRun],
+    config: Union[dict, SweepConfig],
+    validate: bool = False,
+    n: int = 1,
+    minimum_improvement: floating = 0.1,
+):
+    ret: List[SweepRun] = []
+    for _ in range(n):
+        suggestion = bayes_search_next_run(
+            runs + ret, config, validate, minimum_improvement
+        )
+        ret.append(suggestion)
+    return ret

--- a/grid_search.py
+++ b/grid_search.py
@@ -90,18 +90,15 @@ def grid_search_next_runs(
         ]
     )
 
+    hash_gen = (
+        hash_val for hash_val in all_param_hashes if hash_val not in param_hashes_seen
+    )
+
     retval: List[Optional[SweepRun]] = []
     for _ in range(n):
 
         # this is O(1)
-        next_hash = next(
-            (
-                hash_val
-                for hash_val in all_param_hashes
-                if hash_val not in param_hashes_seen
-            ),
-            None,
-        )
+        next_hash = next(hash_gen, None)
 
         # we have searched over the entire parameter space
         if next_hash is None:
@@ -113,5 +110,7 @@ def grid_search_next_runs(
 
         run = SweepRun(config=params.to_config())
         retval.append(run)
+
+        param_hashes_seen.add(next_hash)
 
     return retval

--- a/grid_search.py
+++ b/grid_search.py
@@ -15,27 +15,29 @@ def yaml_hash(value: Any) -> str:
     ).hexdigest()
 
 
-def grid_search_next_run(
+def grid_search_next_runs(
     runs: List[SweepRun],
     sweep_config: Union[dict, SweepConfig],
     validate: bool = False,
+    n: int = 1,
     randomize_order: bool = False,
-) -> Optional[SweepRun]:
+) -> List[Optional[SweepRun]]:
     """Suggest runs with Hyperparameters drawn from a grid.
 
-    >>> suggestion = grid_search_next_run([], {'method': 'grid', 'parameters': {'a': {'values': [1, 2, 3]}}})
-    >>> assert suggestion.config['a']['value'] == 1
+    >>> suggestion = grid_search_next_runs([], {'method': 'grid', 'parameters': {'a': {'values': [1, 2, 3]}}})
+    >>> assert suggestion[0].config['a']['value'] == 1
 
     Args:
         runs: The runs in the sweep.
         sweep_config: The sweep's config.
         randomize_order: Whether to randomize the order of the grid search.
+        n: The number of runs to draw
         validate: Whether to validate `sweep_config` against the SweepConfig JSONschema.
            If true, will raise a Validation error if `sweep_config` does not conform to
            the schema. If false, will attempt to run the sweep with an unvalidated schema.
 
     Returns:
-        The suggested run.
+        The suggested runs.
     """
 
     # make sure the sweep config is valid
@@ -61,6 +63,10 @@ def grid_search_next_run(
     discrete_params = HyperParameterSet(
         [p for p in params if p.type == HyperParameter.CATEGORICAL]
     )
+    constant_params = HyperParameterSet(
+        [p for p in params if p.type == HyperParameter.CONSTANT]
+    )
+    constant_config = constant_params.to_config()
 
     # build an iterator over all combinations of param values
     param_names = [p.name for p in discrete_params]
@@ -88,21 +94,30 @@ def grid_search_next_run(
         ]
     )
 
-    # this is O(N) due to the O(1) complexity of individual hash lookups; previous implementation was O(N^2)
-    next_hash = next(
-        (
-            hash_val
-            for hash_val in all_param_hashes
-            if hash_val not in param_hashes_seen
-        ),
-        None,
-    )
+    retval: List[Optional[SweepRun]] = []
+    for _ in range(n):
 
-    # we have searched over the entire parameter space
-    if next_hash is None:
-        return None
+        # this is O(N) due to the O(1) complexity of individual hash lookups; previous implementation was O(N^2)
+        next_hash = next(
+            (
+                hash_val
+                for hash_val in all_param_hashes
+                if hash_val not in param_hashes_seen
+            ),
+            None,
+        )
 
-    for param, hash_val in zip(discrete_params, next_hash):
-        param.value = value_hash_lookup[param.name][hash_val]
+        # we have searched over the entire parameter space
+        if next_hash is None:
+            retval.append(None)
+            return retval
 
-    return SweepRun(config=params.to_config())
+        for param, hash_val in zip(discrete_params, next_hash):
+            param.value = value_hash_lookup[param.name][hash_val]
+
+        output_config = discrete_params.to_config()
+        output_config.update(constant_config)
+        run = SweepRun(config=output_config)
+        retval.append(run)
+
+    return retval

--- a/grid_search.py
+++ b/grid_search.py
@@ -63,10 +63,6 @@ def grid_search_next_runs(
     discrete_params = HyperParameterSet(
         [p for p in params if p.type == HyperParameter.CATEGORICAL]
     )
-    constant_params = HyperParameterSet(
-        [p for p in params if p.type == HyperParameter.CONSTANT]
-    )
-    constant_config = constant_params.to_config()
 
     # build an iterator over all combinations of param values
     param_names = [p.name for p in discrete_params]
@@ -115,9 +111,7 @@ def grid_search_next_runs(
         for param, hash_val in zip(discrete_params, next_hash):
             param.value = value_hash_lookup[param.name][hash_val]
 
-        output_config = discrete_params.to_config()
-        output_config.update(constant_config)
-        run = SweepRun(config=output_config)
+        run = SweepRun(config=params.to_config())
         retval.append(run)
 
     return retval

--- a/grid_search.py
+++ b/grid_search.py
@@ -93,7 +93,7 @@ def grid_search_next_runs(
     retval: List[Optional[SweepRun]] = []
     for _ in range(n):
 
-        # this is O(N) due to the O(1) complexity of individual hash lookups; previous implementation was O(N^2)
+        # this is O(1)
         next_hash = next(
             (
                 hash_val

--- a/random_search.py
+++ b/random_search.py
@@ -2,24 +2,25 @@ from .config.cfg import SweepConfig
 from .run import SweepRun
 from .params import HyperParameterSet
 
-from typing import Union
+from typing import Union, List
 
 
-def random_search_next_run(
-    sweep_config: Union[dict, SweepConfig], validate: bool = False
-) -> SweepRun:
+def random_search_next_runs(
+    sweep_config: Union[dict, SweepConfig], validate: bool = False, n: int = 1
+) -> List[SweepRun]:
     """Suggest runs with Hyperparameters sampled randomly from specified distributions.
 
-    >>> suggestion = random_search_next_run({'method': 'random', 'parameters': {'a': {'min': 1., 'max': 2.}}})
+    >>> suggestions = random_search_next_runs({'method': 'random', 'parameters': {'a': {'min': 1., 'max': 2.}}})
 
     Args:
         sweep_config: The sweep's config.
         validate: Whether to validate `sweep_config` against the SweepConfig JSONschema.
            If true, will raise a Validation error if `sweep_config` does not conform to
            the schema. If false, will attempt to run the sweep with an unvalidated schema.
+        n: The number of runs to return
 
     Returns:
-        The suggested run.
+        The suggested runs.
     """
 
     # ensure that the sweepconfig is properly formatted
@@ -28,10 +29,13 @@ def random_search_next_run(
 
     if sweep_config["method"] != "random":
         raise ValueError("Invalid sweep configuration for random_search_next_run.")
-
     params = HyperParameterSet.from_config(sweep_config["parameters"])
 
-    for param in params:
-        param.value = param.sample()
+    retval = []
+    for _ in range(n):
+        for param in params:
+            param.value = param.sample()
+        run = SweepRun(config=params.to_config())
+        retval.append(run)
 
-    return SweepRun(config=params.to_config())
+    return retval

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -4,21 +4,22 @@ import numpy as np
 from ..run import next_run, next_runs
 
 
-def reset_seed():
-    np.random.seed(12)
-    random.seed(13)
+def reset_seed(init_seed):
+    np.random.seed(init_seed)
+    random.seed(init_seed + 1)
 
 
 def test_batch_bayes_search_same_answer_as_single_search(
     sweep_config_bayes_search_2params_with_metric,
 ):
-    reset_seed()
+    init_seed = random.randrange(0, 2 ** 32 - 1)
+    reset_seed(init_seed)
     runs = []
     for _ in range(10):
         suggestion = next_run(sweep_config_bayes_search_2params_with_metric, runs)
         runs.append(suggestion)
 
-    reset_seed()
+    reset_seed(init_seed)
     suggestions = next_runs(sweep_config_bayes_search_2params_with_metric, [], n=10)
     assert suggestions == runs
 
@@ -38,21 +39,21 @@ def test_batch_grid_search_same_answer_as_single_search(
         assert s in runs
 
 
-def test_batch_random_search_same_answer_as_single_search(
-    sweep_config_bayes_search_2params_with_metric,
-):
+def test_batch_random_search_same_answer_as_single_search():
 
     config = {
         "method": "random",
         "parameters": {"v1": {"values": [1, 2, 3]}, "v2": {"values": [4, 5]}},
     }
 
-    reset_seed()
+    init_seed = random.randrange(0, 2 ** 32 - 1)
+    reset_seed(init_seed)
+
     runs = []
     for _ in range(10):
         suggestion = next_run(config, runs)
         runs.append(suggestion)
 
-    reset_seed()
+    reset_seed(init_seed)
     suggestions = next_runs(config, [], n=10)
     assert suggestions == runs

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -1,0 +1,58 @@
+import random
+
+import numpy as np
+from ..run import next_run, next_runs
+
+
+def reset_seed():
+    np.random.seed(12)
+    random.seed(13)
+
+
+def test_batch_bayes_search_same_answer_as_single_search(
+    sweep_config_bayes_search_2params_with_metric,
+):
+    reset_seed()
+    runs = []
+    for _ in range(10):
+        suggestion = next_run(sweep_config_bayes_search_2params_with_metric, runs)
+        runs.append(suggestion)
+
+    reset_seed()
+    suggestions = next_runs(sweep_config_bayes_search_2params_with_metric, [], n=10)
+    assert suggestions == runs
+
+
+def test_batch_grid_search_same_answer_as_single_search(
+    sweep_config_2params_grid_search,
+):
+    runs = []
+    for _ in range(7):
+        suggestion = next_run(sweep_config_2params_grid_search, runs)
+        runs.append(suggestion)
+
+    suggestions = next_runs(sweep_config_2params_grid_search, [], n=7)
+
+    assert len(suggestions) == len(runs)
+    for s in suggestions:
+        assert s in runs
+
+
+def test_batch_random_search_same_answer_as_single_search(
+    sweep_config_bayes_search_2params_with_metric,
+):
+
+    config = {
+        "method": "random",
+        "parameters": {"v1": {"values": [1, 2, 3]}, "v2": {"values": [4, 5]}},
+    }
+
+    reset_seed()
+    runs = []
+    for _ in range(10):
+        suggestion = next_run(config, runs)
+        runs.append(suggestion)
+
+    reset_seed()
+    suggestions = next_runs(config, [], n=10)
+    assert suggestions == runs

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -33,10 +33,7 @@ def test_batch_grid_search_same_answer_as_single_search(
         runs.append(suggestion)
 
     suggestions = next_runs(sweep_config_2params_grid_search, [], n=7)
-
-    assert len(suggestions) == len(runs)
-    for s in suggestions:
-        assert s in runs
+    assert suggestions == runs
 
 
 def test_batch_random_search_same_answer_as_single_search():

--- a/tests/test_grid_search.py
+++ b/tests/test_grid_search.py
@@ -1,6 +1,6 @@
 import pytest
 
-from typing import List, Optional, Sequence, Tuple
+from typing import List, Sequence, Tuple
 from ..run import RunState, SweepRun, next_run, next_runs
 from ..config import SweepConfig
 
@@ -24,7 +24,7 @@ def kernel_for_grid_search_tests(
         for run in runs
     ]
 
-    def handle_suggestion(suggestion: Optional[SweepRun]):
+    def handle_suggestion(suggestion: SweepRun):
         assert suggestion.search_info is None
         assert suggestion.state == RunState.pending
         runs.append(suggestion)

--- a/tests/test_grid_search.py
+++ b/tests/test_grid_search.py
@@ -1,7 +1,7 @@
 import pytest
 
-from typing import List, Sequence, Tuple
-from ..run import RunState, SweepRun, next_run
+from typing import List, Optional, Sequence, Tuple
+from ..run import RunState, SweepRun, next_run, next_runs
 from ..config import SweepConfig
 
 
@@ -11,6 +11,7 @@ def kernel_for_grid_search_tests(
     answers: Sequence[Tuple],
     randomize: bool,
     check_order: bool = False,
+    vectorize: bool = False,
 ) -> None:
     """This kernel assumes that sweep config has two categorical parameters
     named v1 and v2."""
@@ -23,10 +24,7 @@ def kernel_for_grid_search_tests(
         for run in runs
     ]
 
-    while True:
-        suggestion = next_run(config, runs, randomize_order=randomize)
-        if suggestion is None:  # done
-            break
+    def handle_suggestion(suggestion: Optional[SweepRun]):
         assert suggestion.search_info is None
         assert suggestion.state == RunState.pending
         runs.append(suggestion)
@@ -37,6 +35,21 @@ def kernel_for_grid_search_tests(
             )
         )
 
+    done = False
+    while not done:
+        if not vectorize:
+            suggestion = next_run(config, runs, randomize_order=randomize)
+            if suggestion is None:  # done
+                break
+            handle_suggestion(suggestion)
+        else:
+            suggestions = next_runs(config, runs, randomize_order=randomize, n=500)
+            for suggestion in suggestions:
+                if suggestion is None:
+                    done = True
+                    break
+                handle_suggestion(suggestion)
+
     assert len(answers) == len(suggested_parameters)
     for i, key in enumerate(suggested_parameters):
         if check_order:
@@ -45,21 +58,24 @@ def kernel_for_grid_search_tests(
             assert key in answers
 
 
+@pytest.mark.parametrize("vectorize", [True, False])
 @pytest.mark.parametrize("randomize", [True, False])
 def test_grid_from_start_with_and_without_randomize(
-    sweep_config_2params_grid_search, randomize
+    sweep_config_2params_grid_search, randomize, vectorize
 ):
     kernel_for_grid_search_tests(
         [],
         sweep_config_2params_grid_search,
         randomize=randomize,
+        vectorize=vectorize,
         answers=[(1, 4), (1, 5), (2, 4), (2, 5), (3, 4), (3, 5)],
     )
 
 
+@pytest.mark.parametrize("vectorize", [True, False])
 @pytest.mark.parametrize("randomize", [True, False])
 def test_grid_search_starting_from_in_progress(
-    sweep_config_2params_grid_search, randomize
+    sweep_config_2params_grid_search, randomize, vectorize
 ):
     runs = [
         SweepRun(config={"v1": {"value": 2}, "v2": {"value": 4}}),
@@ -70,10 +86,12 @@ def test_grid_search_starting_from_in_progress(
         sweep_config_2params_grid_search,
         randomize=randomize,
         answers=[(1, 4), (1, 5), (2, 4), (2, 5), (3, 4), (3, 5)],
+        vectorize=vectorize,
     )
 
 
-def test_grid_search_with_list_values():
+@pytest.mark.parametrize("vectorize", [True, False])
+def test_grid_search_with_list_values(vectorize):
     # https://sentry.io/organizations/weights-biases/issues/2501125152/?project=5812400&query=is%3Aresolved&statsPeriod=14d
     config = SweepConfig(
         {
@@ -94,10 +112,12 @@ def test_grid_search_with_list_values():
         config,
         randomize=False,
         answers=[("", 256), ("", 512), ([9, 5], 256), ([9, 5], 512)],
+        vectorize=vectorize,
     )
 
 
-def test_grid_search_duplicated_values_are_not_duplicated_in_answer():
+@pytest.mark.parametrize("vectorize", [True, False])
+def test_grid_search_duplicated_values_are_not_duplicated_in_answer(vectorize):
     duplicated_config = SweepConfig(
         {
             "method": "grid",
@@ -113,6 +133,7 @@ def test_grid_search_duplicated_values_are_not_duplicated_in_answer():
         runs,
         duplicated_config,
         randomize=True,
+        vectorize=vectorize,
         answers=[
             (
                 None,
@@ -184,7 +205,8 @@ def test_grid_search_constant_val_is_propagated():
     assert "v2" in run.config
 
 
-def test_grid_search_constant_vals_only():
+@pytest.mark.parametrize("vectorize", [True, False])
+def test_grid_search_constant_vals_only(vectorize):
     config_const = SweepConfig(
         {
             "method": "grid",
@@ -202,11 +224,13 @@ def test_grid_search_constant_vals_only():
             ("a", "b"),
         ],
         randomize=False,
+        vectorize=vectorize,
     )
 
 
+@pytest.mark.parametrize("vectorize", [True, False])
 @pytest.mark.parametrize("randomize", [True, False])
-def test_grid_search_dict_val_is_propagated(randomize):
+def test_grid_search_dict_val_is_propagated(randomize, vectorize):
     config_const = SweepConfig(
         {
             "method": "grid",
@@ -229,6 +253,7 @@ def test_grid_search_dict_val_is_propagated(randomize):
         [],
         config_const,
         randomize=randomize,
+        vectorize=vectorize,
         answers=[
             ("a", {"a": "b"}),
             ("a", {"c": "d", "b": "g"}),
@@ -243,7 +268,8 @@ def test_grid_search_dict_val_is_propagated(randomize):
     )
 
 
-def test_grid_search_anaconda1_order():
+@pytest.mark.parametrize("vectorize", [True, False])
+def test_grid_search_anaconda1_order(vectorize):
     config_const = SweepConfig(
         {
             "method": "grid",
@@ -270,4 +296,5 @@ def test_grid_search_anaconda1_order():
             ("c", 3),
         ],
         check_order=True,
+        vectorize=vectorize,
     )

--- a/tests/test_grid_search.py
+++ b/tests/test_grid_search.py
@@ -205,6 +205,44 @@ def test_grid_search_constant_vals_only():
     )
 
 
+@pytest.mark.parametrize("randomize", [True, False])
+def test_grid_search_dict_val_is_propagated(randomize):
+    config_const = SweepConfig(
+        {
+            "method": "grid",
+            "parameters": {
+                "v1": {"values": ["a", "b", "c'"]},
+                "v2": {
+                    "values": [
+                        {"a": "b"},
+                        {"c": "d", "b": "g"},
+                        {"e": {"f": "g"}},
+                        {"a": "b"},
+                        {"b": "g", "c": "d"},
+                    ]
+                },
+            },
+        }
+    )
+
+    kernel_for_grid_search_tests(
+        [],
+        config_const,
+        randomize=randomize,
+        answers=[
+            ("a", {"a": "b"}),
+            ("a", {"c": "d", "b": "g"}),
+            ("a", {"e": {"f": "g"}}),
+            ("b", {"a": "b"}),
+            ("b", {"c": "d", "b": "g"}),
+            ("b", {"e": {"f": "g"}}),
+            ("c'", {"a": "b"}),
+            ("c'", {"c": "d", "b": "g"}),
+            ("c'", {"e": {"f": "g"}}),
+        ],
+    )
+
+
 def test_grid_search_anaconda1_order():
     config_const = SweepConfig(
         {

--- a/tests/test_grid_search.py
+++ b/tests/test_grid_search.py
@@ -184,22 +184,13 @@ def test_grid_search_constant_val_is_propagated():
     assert "v2" in run.config
 
 
-@pytest.mark.parametrize("randomize", [True, False])
-def test_grid_search_dict_val_is_propagated(randomize):
+def test_grid_search_constant_vals_only():
     config_const = SweepConfig(
         {
             "method": "grid",
             "parameters": {
-                "v1": {"values": ["a", "b", "c'"]},
-                "v2": {
-                    "values": [
-                        {"a": "b"},
-                        {"c": "d", "b": "g"},
-                        {"e": {"f": "g"}},
-                        {"a": "b"},
-                        {"b": "g", "c": "d"},
-                    ]
-                },
+                "v1": {"value": "a"},
+                "v2": {"value": "b"},
             },
         }
     )
@@ -207,18 +198,10 @@ def test_grid_search_dict_val_is_propagated(randomize):
     kernel_for_grid_search_tests(
         [],
         config_const,
-        randomize=randomize,
         answers=[
-            ("a", {"a": "b"}),
-            ("a", {"c": "d", "b": "g"}),
-            ("a", {"e": {"f": "g"}}),
-            ("b", {"a": "b"}),
-            ("b", {"c": "d", "b": "g"}),
-            ("b", {"e": {"f": "g"}}),
-            ("c'", {"a": "b"}),
-            ("c'", {"c": "d", "b": "g"}),
-            ("c'", {"e": {"f": "g"}}),
+            ("a", "b"),
         ],
+        randomize=False,
     )
 
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -2,9 +2,9 @@ import pytest
 from jsonschema import ValidationError
 from .. import next_run, stop_runs, SweepRun
 from ..config import SweepConfig, schema_violations_from_proposed_config
-from ..bayes_search import bayes_search_next_run
-from ..grid_search import grid_search_next_run
-from ..random_search import random_search_next_run
+from ..bayes_search import bayes_search_next_runs
+from ..grid_search import grid_search_next_runs
+from ..random_search import random_search_next_runs
 from ..hyperband_stopping import hyperband_stop_runs
 
 
@@ -27,11 +27,11 @@ def test_validation_disable(search_type):
 
     with pytest.raises(ValidationError):
         if search_type == "bayes":
-            _ = bayes_search_next_run([], invalid_schema, validate=True)
+            _ = bayes_search_next_runs([], invalid_schema, validate=True)
         elif search_type == "grid":
-            _ = grid_search_next_run([], invalid_schema, validate=True)
+            _ = grid_search_next_runs([], invalid_schema, validate=True)
         elif search_type == "random":
-            _ = random_search_next_run(invalid_schema, validate=True)
+            _ = random_search_next_runs(invalid_schema, validate=True)
 
     # check that no error is raised
     result = next_run(invalid_schema, [], validate=False)


### PR DESCRIPTION
This PR contains the `wandb/sweeps` changes required to support run-queue backed sweeps. 

These are:

1. Optional vectorization of `next_runs` for all three sweep types (needed to support `NextNArgs`).
2. Integration of vectorized` next_runs` with new `yaml` hashing scheme for tracking parameters with mutable python representations

I added unit tests for the former (`test_batch.py`) and old tests serve to check the latter. 

The plan is to deploy this to shadow before rolling out run queue backed sweeps. 