### PR TITLE
[WB-6506] Ensure metrics are numeric in bayes search

### DIFF
--- a/run.py
+++ b/run.py
@@ -23,7 +23,12 @@ class RunState(str, Enum):
 def is_number(x: Any) -> bool:
     """Check if a value is a finite number."""
     try:
-        return np.isscalar(x) and np.isfinite(x) and isinstance(x, Number)
+        return (
+            np.isscalar(x)
+            and np.isfinite(x)
+            and isinstance(x, Number)
+            and not isinstance(x, bool)
+        )
     except TypeError:
         return False
 


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-6506
https://sentry.io/organizations/weights-biases/issues/2594096263/?referrer=jira_integration

Description
-----------

This PR fixes an issue from sentry, where a user tried to run a bayesian sweep with runs that had non-numeric metrics. This PR adds a check that run metrics be numeric so they can be regressed via a GP. 

Testing
-------

Added a unit test to see that runs with non-numeric metrics are rejected by Bayes search.