### PR TITLE
[WB-6684] Add support for bounded distributions in grid search

### DIFF
--- a/src/sweeps/grid_search.py
+++ b/src/sweeps/grid_search.py
@@ -72,7 +72,7 @@ def grid_search_next_runs(
             params[i] = HyperParameter(
                 p.name,
                 {
-                    "type": "categorical",
+                    "distribution": "categorical",
                     "values": [
                         val for val in range(p.config["min"], p.config["max"] + 1)
                     ],
@@ -82,7 +82,7 @@ def grid_search_next_runs(
             params[i] = HyperParameter(
                 p.name,
                 {
-                    "type": "categorical",
+                    "distribution": "categorical",
                     "values": np.linspace(
                         p.config["min"], p.config["max"], p.config["q"]
                     ).tolist(),

--- a/src/sweeps/grid_search.py
+++ b/src/sweeps/grid_search.py
@@ -83,7 +83,7 @@ def grid_search_next_runs(
                 p.name,
                 {
                     "distribution": "categorical",
-                    "values": np.linspace(
+                    "values": np.arange(
                         p.config["min"], p.config["max"], p.config["q"]
                     ).tolist(),
                 },

--- a/src/sweeps/grid_search.py
+++ b/src/sweeps/grid_search.py
@@ -4,6 +4,8 @@ import hashlib
 import yaml
 from typing import Any, List, Optional, Union
 
+import numpy as np
+
 from .config.cfg import SweepConfig
 from .run import SweepRun
 from .params import HyperParameter, HyperParameterSet
@@ -53,10 +55,38 @@ def grid_search_next_runs(
 
     # Check that all parameters are categorical or constant
     for p in params:
-        if p.type != HyperParameter.CATEGORICAL and p.type != HyperParameter.CONSTANT:
+        if p.type not in [
+            HyperParameter.CATEGORICAL,
+            HyperParameter.CONSTANT,
+            HyperParameter.INT_UNIFORM,
+            HyperParameter.Q_UNIFORM,
+        ]:
             raise ValueError(
-                "Parameter %s is a disallowed type with grid search. Grid search requires all parameters to be categorical or constant"
-                % p.name
+                f"Parameter {p.name} is a disallowed type with grid search. Grid search requires all parameters "
+                f"to be categorical, constant, int_uniform, or q_uniform."
+            )
+
+    # convert bounded int_uniform and q_uniform parameters to categorical parameters
+    for i, p in enumerate(params):
+        if p.type == HyperParameter.INT_UNIFORM:
+            params[i] = HyperParameter(
+                p.name,
+                {
+                    "type": "categorical",
+                    "values": [
+                        val for val in range(p.config["min"], p.config["max"] + 1)
+                    ],
+                },
+            )
+        elif p.type == HyperParameter.Q_UNIFORM:
+            params[i] = HyperParameter(
+                p.name,
+                {
+                    "type": "categorical",
+                    "values": np.linspace(
+                        p.config["min"], p.config["max"], p.config["q"]
+                    ).tolist(),
+                },
             )
 
     # we can only deal with discrete params in a grid search

--- a/tests/test_grid_search.py
+++ b/tests/test_grid_search.py
@@ -298,3 +298,25 @@ def test_grid_search_anaconda1_order(vectorize):
         check_order=True,
         vectorize=vectorize,
     )
+
+
+@pytest.mark.parametrize("vectorize", [True, False])
+@pytest.mark.parametrize("randomize", [True, False])
+def test_int_uniform_bounded_grid_search(randomize, vectorize):
+    int_uniform_config = SweepConfig(
+        {
+            "method": "grid",
+            "parameters": {
+                "v1": {"distribution": "int_uniform", "min": -52, "max": 10},
+                "v2": {"value": "test"},
+            },
+        }
+    )
+
+    kernel_for_grid_search_tests(
+        [],
+        int_uniform_config,
+        randomize=randomize,
+        vectorize=vectorize,
+        answers=[(v, "test") for v in range(-52, 11)],
+    )

--- a/tests/test_grid_search.py
+++ b/tests/test_grid_search.py
@@ -4,6 +4,8 @@ from typing import List, Sequence, Tuple
 from sweeps.run import RunState, SweepRun, next_run, next_runs
 from sweeps.config import SweepConfig
 
+import numpy as np
+
 
 def kernel_for_grid_search_tests(
     runs: List[SweepRun],
@@ -319,4 +321,31 @@ def test_int_uniform_bounded_grid_search(randomize, vectorize):
         randomize=randomize,
         vectorize=vectorize,
         answers=[(v, "test") for v in range(-52, 11)],
+    )
+
+
+@pytest.mark.parametrize("vectorize", [True, False])
+@pytest.mark.parametrize("randomize", [True, False])
+def test_q_uniform_bounded_grid_search(randomize, vectorize):
+    int_uniform_config = SweepConfig(
+        {
+            "method": "grid",
+            "parameters": {
+                "v1": {
+                    "distribution": "q_uniform",
+                    "min": -9.211,
+                    "max": 23.23,
+                    "q": 2.341,
+                },
+                "v2": {"value": "test"},
+            },
+        }
+    )
+
+    kernel_for_grid_search_tests(
+        [],
+        int_uniform_config,
+        randomize=randomize,
+        vectorize=vectorize,
+        answers=[(v, "test") for v in np.arange(-9.211, 23.23, 2.341)],
     )

--- a/tox.ini
+++ b/tox.ini
@@ -10,4 +10,4 @@ install_command =
     pip install {opts} {packages}
 
 commands =
-    pytest
+    pytest {posargs}


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-6684

Description
------------

This PR adds support for bounded distributions in grid search sweeps. The supported distributions are `q_uniform` and `int_uniform`. It works by converting these parameters to categorical parameters on the backend and iterating over them. 

Testing
-------

Added unit tests. 
