### PR TITLE
[WB-7198] run validate min max in fill_parameter

### DIFF
--- a/src/sweeps/config/cfg.py
+++ b/src/sweeps/config/cfg.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Union, Dict, List
 
 import jsonschema
-from .schema import validator, fill_validate_schema
+from .schema import validator, fill_validate_schema, validate_min_max
 from copy import deepcopy
 
 
@@ -28,13 +28,10 @@ def schema_violations_from_proposed_config(config: Dict) -> List[str]:
                 raise ValueError(
                     f"Invalid configuration for hyperparameter '{parameter_name}'"
                 )
-            if "min" in parameter_dict and "max" in parameter_dict:
-                # this comparison is type safe because the jsonschema enforces type uniformity
-                if parameter_dict["min"] >= parameter_dict["max"]:
-                    schema_violation_messages.append(
-                        f'{parameter_name}: min {parameter_dict["min"]} is not '
-                        f'less than max {parameter_dict["max"]}'
-                    )
+            try:
+                validate_min_max(parameter_name, parameter_dict)
+            except ValueError as e:
+                schema_violation_messages.append(e.args[0])
     return schema_violation_messages
 
 

--- a/src/sweeps/config/schema.py
+++ b/src/sweeps/config/schema.py
@@ -67,7 +67,7 @@ default_filler = DefaultFiller(
 )
 
 
-def fill_parameter(config: Dict) -> Optional[Tuple[str, Dict]]:
+def fill_parameter(parameter_name: str, config: Dict) -> Optional[Tuple[str, Dict]]:
     # names of the parameter definitions that are allowed
     allowed_schemas = [
         d["$ref"].split("/")[-1]
@@ -85,14 +85,24 @@ def fill_parameter(config: Dict) -> Optional[Tuple[str, Dict]]:
         except jsonschema.ValidationError:
             continue
         else:
+            validate_min_max(parameter_name, config)
             filler = DefaultFiller(subschema, format_checker=format_checker)
-
             # this sets the defaults, modifying config inplace
             config = deepcopy(config)
             filler.validate(config)
             return schema_name, config
 
     return None
+
+
+def validate_min_max(parameter_name: str, parameter_config: Dict) -> None:
+    if "min" in parameter_config and "max" in parameter_config:
+        # this comparison is type safe because the jsonschema enforces type uniformity
+        if parameter_config["min"] >= parameter_config["max"]:
+            raise ValueError(
+                f'{parameter_name}: min {parameter_config["min"]} is not '
+                f'less than max {parameter_config["max"]}'
+            )
 
 
 def fill_validate_metric(d: Dict) -> Dict:
@@ -143,7 +153,7 @@ def fill_validate_schema(d: Dict) -> Dict:
     # update the parameters
     filled = {}
     for k, v in validated["parameters"].items():
-        result = fill_parameter(v)
+        result = fill_parameter(k, v)
         if result is None:
             raise jsonschema.ValidationError(f"Parameter {k} is malformed")
         _, config = result

--- a/src/sweeps/params.py
+++ b/src/sweeps/params.py
@@ -45,7 +45,7 @@ class HyperParameter:
 
         self.name = name
 
-        result = fill_parameter(config)
+        result = fill_parameter(name, config)
         if result is None:
             raise jsonschema.ValidationError(
                 f"invalid hyperparameter configuration: {name}"

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,7 +1,11 @@
 import pytest
 from jsonschema import ValidationError
 from sweeps import next_run, stop_runs, SweepRun
-from sweeps.config import SweepConfig, schema_violations_from_proposed_config
+from sweeps.config import (
+    SweepConfig,
+    schema_violations_from_proposed_config,
+    fill_parameter,
+)
 from sweeps.bayes_search import bayes_search_next_runs
 from sweeps.grid_search import grid_search_next_runs
 from sweeps.random_search import random_search_next_runs
@@ -149,3 +153,10 @@ def test_invalid_run_parameter():
 
     with pytest.raises(ValueError):
         next_run(config, runs, validate=False)
+
+
+def test_invalid_minmax_with_no_sweepconfig_validation():
+    config = {"method": "random", "parameters": {"a": {"max": 0, "min": 1}}}
+
+    with pytest.raises(ValueError):
+        fill_parameter("a", config["parameters"]["a"])


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-7198

Description:

Causes sweeps with invalid min/max (i.e., max < min) to fail on upsert, rather than warn but produce nonsensical output. 

Doesn't break backwards compatibility with anaconda1: this should have been included in the original sweeps overhaul but I missed it.

testing:
added a unit test. 