### PR TITLE
[WB-7227][WB-7226] catch case where invalid metric section of sweep config can pass through as a string

### DIFF
--- a/src/sweeps/config/schema.py
+++ b/src/sweeps/config/schema.py
@@ -109,6 +109,10 @@ def fill_validate_metric(d: Dict) -> Dict:
     d = deepcopy(d)
 
     if "metric" in d:
+        if not isinstance(d["metric"], dict):
+            raise ValueError(
+                f"invalid type for metric: expected dict, got {type(d['metric'])}"
+            )
         if "goal" in d["metric"]:
             if (
                 d["metric"]["goal"]

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2,6 +2,7 @@ import pytest
 import jsonschema
 from sweeps.params import HyperParameter
 from sweeps.config import SweepConfig, fill_validate_early_terminate
+from sweeps.config.schema import fill_validate_metric
 from sweeps.hyperband_stopping import hyperband_baseline_validate_and_fill
 
 
@@ -230,3 +231,14 @@ def test_hyperband_incremental_corrects_goal():
     sc = hyperband_baseline_validate_and_fill(config)
     assert sc["early_terminate"]["eta"] == 3
     assert sc["metric"]["goal"] == "minimize"
+
+
+def test_invalid_metric():
+    config = {
+        "method": "grid",
+        "metric": "{'goal': 'maximize', 'name': 'val/loss'}",
+        "parameters": {"a": {"values": [1, 2, 3, 4]}},
+    }
+
+    with pytest.raises(ValueError):
+        fill_validate_metric(config)


### PR DESCRIPTION
Description

`fill_validate_metric` did not raise when passed a config with a metric section that was a string that contained `"goal"`. This fixes `fill_validate_metric` to require that it is a dict and not a string 

Tests
Added a unit test 