### PR TITLE
Add inverse log uniform distribution

### DIFF
--- a/src/sweeps/config/schema.json
+++ b/src/sweeps/config/schema.json
@@ -565,16 +565,21 @@
       ]
     },
     "controller": {
-	"type": "object",
-	"properties": {
-	    "type": {
-		"type": "string",
-		"description": "Which controller to use, local or cloud",
-		"enum": ["local", "cloud"],
-		"default": "cloud"
-	    }
-	},
-	"required": ["type"]
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "Which controller to use, local or cloud",
+          "enum": [
+            "local",
+            "cloud"
+          ],
+          "default": "cloud"
+        }
+      },
+      "required": [
+        "type"
+      ]
     },
     "description": {
       "type": "string",

--- a/src/sweeps/config/schema.json
+++ b/src/sweeps/config/schema.json
@@ -309,7 +309,8 @@
             "inv_log_uniform"
           ]
         }
-      }
+      },
+      "additionalProperties": false
     },
     "param_quniform": {
       "type": "object",

--- a/src/sweeps/config/schema.json
+++ b/src/sweeps/config/schema.json
@@ -297,13 +297,11 @@
       "properties": {
         "min": {
           "description": "float",
-          "type": "number",
-          "exclusiveMinimum": 0
+          "type": "number"
         },
         "max": {
           "description": "float",
-          "type": "number",
-          "exclusiveMinimum": 0
+          "type": "number"
         },
         "distribution": {
           "enum": [

--- a/src/sweeps/config/schema.json
+++ b/src/sweeps/config/schema.json
@@ -302,7 +302,8 @@
         },
         "max": {
           "description": "float",
-          "type": "number"
+          "type": "number",
+          "exclusiveMinimum": 0
         },
         "distribution": {
           "enum": [

--- a/src/sweeps/config/schema.json
+++ b/src/sweeps/config/schema.json
@@ -297,7 +297,8 @@
       "properties": {
         "min": {
           "description": "float",
-          "type": "number"
+          "type": "number",
+          "exclusiveMinimum": 0
         },
         "max": {
           "description": "float",

--- a/src/sweeps/config/schema.json
+++ b/src/sweeps/config/schema.json
@@ -286,6 +286,30 @@
       },
       "additionalProperties": false
     },
+    "param_inv_loguniform": {
+      "type": "object",
+      "description": "inverse log uniform distribution",
+      "required": [
+        "distribution",
+        "max",
+        "min"
+      ],
+      "properties": {
+        "min": {
+          "description": "float",
+          "type": "number"
+        },
+        "max": {
+          "description": "float",
+          "type": "number"
+        },
+        "distribution": {
+          "enum": [
+            "inv_log_uniform"
+          ]
+        }
+      }
+    },
     "param_quniform": {
       "type": "object",
       "description": "quantized uniform distribution function.",
@@ -449,6 +473,9 @@
         },
         {
           "$ref": "#/definitions/param_loguniform"
+        },
+        {
+          "$ref": "#/definitions/param_inv_loguniform"
         },
         {
           "$ref": "#/definitions/param_normal"

--- a/src/sweeps/params.py
+++ b/src/sweeps/params.py
@@ -122,8 +122,8 @@ class HyperParameter:
         elif self.type == HyperParameter.INV_LOG_UNIFORM:
             return 1 - stats.uniform.cdf(
                 np.log(1 / x),
-                1 / np.exp(self.config["max"]),
-                1 / np.exp(self.config["min"]) - 1 / np.exp(self.config["max"]),
+                self.config["min"],
+                self.config["max"] - self.config["min"],
             )
         elif self.type == HyperParameter.NORMAL or self.type == HyperParameter.Q_NORMAL:
             return stats.norm.cdf(x, loc=self.config["mu"], scale=self.config["sigma"])
@@ -191,10 +191,10 @@ class HyperParameter:
                 )
             )
         elif self.type == HyperParameter.INV_LOG_UNIFORM:
-            return 1.0 / np.exp(
-                stats.uniform.ppf(
+            return np.exp(
+                -stats.uniform.ppf(
                     1 - x,
-                    -self.config["max"],
+                    self.config["min"],
                     self.config["max"] - self.config["min"],
                 )
             )

--- a/src/sweeps/params.py
+++ b/src/sweeps/params.py
@@ -21,6 +21,7 @@ class HyperParameter:
     INT_UNIFORM = "param_int_uniform"
     UNIFORM = "param_uniform"
     LOG_UNIFORM = "param_loguniform"
+    INV_LOG_UNIFORM = "param_inv_loguniform"
     Q_UNIFORM = "param_quniform"
     Q_LOG_UNIFORM = "param_qloguniform"
     NORMAL = "param_normal"
@@ -118,6 +119,10 @@ class HyperParameter:
             return stats.uniform.cdf(
                 np.log(x), self.config["min"], self.config["max"] - self.config["min"]
             )
+        elif self.type == HyperParameter.INV_LOG_UNIFORM:
+            return 1 - stats.uniform.cdf(
+                np.log(1/x), 1/self.config["max"], 1/self.config["min"] - 1/self.config["max"]
+            )
         elif self.type == HyperParameter.NORMAL or self.type == HyperParameter.Q_NORMAL:
             return stats.norm.cdf(x, loc=self.config["mu"], scale=self.config["sigma"])
         elif (
@@ -182,6 +187,12 @@ class HyperParameter:
                 stats.uniform.ppf(
                     x, self.config["min"], self.config["max"] - self.config["min"]
                 )
+            )
+        elif self.type == HyperParameter.INV_LOG_UNIFORM:
+            return 1./np.exp(
+                stats.uniform.ppf(
+                    1 - x, np.log(1./self.config["max"]),
+                    np.log(1./self.config["min"]) - np.log(1./self.config["max"]))
             )
         elif self.type == HyperParameter.Q_LOG_UNIFORM:
             r = np.exp(

--- a/src/sweeps/params.py
+++ b/src/sweeps/params.py
@@ -122,8 +122,8 @@ class HyperParameter:
         elif self.type == HyperParameter.INV_LOG_UNIFORM:
             return 1 - stats.uniform.cdf(
                 np.log(1 / x),
-                1 / self.config["max"],
-                1 / self.config["min"] - 1 / self.config["max"],
+                1 / np.exp(self.config["max"]),
+                1 / np.exp(self.config["min"]) - 1 / np.exp(self.config["max"]),
             )
         elif self.type == HyperParameter.NORMAL or self.type == HyperParameter.Q_NORMAL:
             return stats.norm.cdf(x, loc=self.config["mu"], scale=self.config["sigma"])
@@ -194,8 +194,8 @@ class HyperParameter:
             return 1.0 / np.exp(
                 stats.uniform.ppf(
                     1 - x,
-                    np.log(1.0 / self.config["max"]),
-                    np.log(1.0 / self.config["min"]) - np.log(1.0 / self.config["max"]),
+                    np.log(1.0 / np.exp(self.config["max"])),
+                    np.log(1.0 / np.exp(self.config["min"])) - np.log(1.0 / np.exp(self.config["max"])),
                 )
             )
         elif self.type == HyperParameter.Q_LOG_UNIFORM:

--- a/src/sweeps/params.py
+++ b/src/sweeps/params.py
@@ -194,8 +194,8 @@ class HyperParameter:
             return 1.0 / np.exp(
                 stats.uniform.ppf(
                     1 - x,
-                    np.log(1.0 / np.exp(self.config["max"])),
-                    np.log(1.0 / np.exp(self.config["min"])) - np.log(1.0 / np.exp(self.config["max"])),
+                    -self.config["max"],
+                    self.config["max"] - self.config["min"],
                 )
             )
         elif self.type == HyperParameter.Q_LOG_UNIFORM:

--- a/src/sweeps/params.py
+++ b/src/sweeps/params.py
@@ -121,7 +121,9 @@ class HyperParameter:
             )
         elif self.type == HyperParameter.INV_LOG_UNIFORM:
             return 1 - stats.uniform.cdf(
-                np.log(1/x), 1/self.config["max"], 1/self.config["min"] - 1/self.config["max"]
+                np.log(1 / x),
+                1 / self.config["max"],
+                1 / self.config["min"] - 1 / self.config["max"],
             )
         elif self.type == HyperParameter.NORMAL or self.type == HyperParameter.Q_NORMAL:
             return stats.norm.cdf(x, loc=self.config["mu"], scale=self.config["sigma"])
@@ -189,10 +191,12 @@ class HyperParameter:
                 )
             )
         elif self.type == HyperParameter.INV_LOG_UNIFORM:
-            return 1./np.exp(
+            return 1.0 / np.exp(
                 stats.uniform.ppf(
-                    1 - x, np.log(1./self.config["max"]),
-                    np.log(1./self.config["min"]) - np.log(1./self.config["max"]))
+                    1 - x,
+                    np.log(1.0 / self.config["max"]),
+                    np.log(1.0 / self.config["min"]) - np.log(1.0 / self.config["max"]),
+                )
             )
         elif self.type == HyperParameter.Q_LOG_UNIFORM:
             r = np.exp(

--- a/tests/test_random_search.py
+++ b/tests/test_random_search.py
@@ -205,19 +205,23 @@ def test_rand_loguniform(plot):
 
 
 def test_rand_inv_loguniform(plot):
-    # Calculates that the
 
-    v2_max = 1e3
-    v2_min = 1e-3
-    n_samples = 1000
+    # samples of v2 are between 1e-15 and 1e20
+    v2_min = 1e-15
+    v2_max = 1e20
+
+    # limits for sweep config are in log(1/x) space
+    limit_min = np.log(1 / v2_max)
+    limit_max = np.log(1 / v2_min)
+    n_samples = 10000
 
     sweep_config_2params = SweepConfig(
         {
             "method": "random",
             "parameters": {
                 "v2": {
-                    "min": np.log(v2_min),
-                    "max": np.log(v2_max),
+                    "min": limit_min,
+                    "max": limit_max,
                     "distribution": "inv_log_uniform",
                 },
             },
@@ -230,9 +234,7 @@ def test_rand_inv_loguniform(plot):
         runs.append(suggestion)
 
     pred_samples = np.asarray([run.config["v2"]["value"] for run in runs])
-    true_samples = np.random.uniform(
-        np.log(1 / v2_max), np.log(1 / v2_min), size=n_samples
-    )
+    true_samples = np.random.uniform(limit_min, limit_max, size=n_samples)
     true_samples = np.exp(true_samples)
     true_samples = 1 / true_samples
 

--- a/tests/test_random_search.py
+++ b/tests/test_random_search.py
@@ -230,9 +230,11 @@ def test_rand_inv_loguniform(plot):
         runs.append(suggestion)
 
     pred_samples = np.asarray([run.config["v2"]["value"] for run in runs])
-    true_samples = np.random.uniform(np.log(1/v2_max), np.log(1/v2_min), size=n_samples)
+    true_samples = np.random.uniform(
+        np.log(1 / v2_max), np.log(1 / v2_min), size=n_samples
+    )
     true_samples = np.exp(true_samples)
-    true_samples = 1/true_samples
+    true_samples = 1 / true_samples
 
     # the lhs needs to be >= 0 because
     bins = np.logspace(np.log10(v2_min), np.log10(v2_max), 10)

--- a/tests/test_random_search.py
+++ b/tests/test_random_search.py
@@ -214,7 +214,7 @@ def test_rand_inv_loguniform(plot):
     # limits for sweep config are in log(1/x) space
     limit_min = np.log(1 / v2_max)
     limit_max = np.log(1 / v2_min)
-    n_samples = 10000
+    n_samples = 20000
 
     param_config = {
         "min": limit_min,

--- a/tests/test_random_search.py
+++ b/tests/test_random_search.py
@@ -287,8 +287,8 @@ def test_rand_inv_loguniform(plot):
         fname = f"{current_test}.cdf.pdf"
         fig.savefig(test_results_dir / fname)
 
-    # assert that the cdfs are within 0.01 everywhere
-    np.testing.assert_array_less(np.abs(cdf_pred - cdf_empirical), 0.01)
+    # assert that the cdfs are within 0.03 everywhere
+    np.testing.assert_array_less(np.abs(cdf_pred - cdf_empirical), 0.03)
 
 
 @pytest.mark.parametrize("q", [0.1, 1, 10])

--- a/tests/test_random_search.py
+++ b/tests/test_random_search.py
@@ -207,7 +207,6 @@ def test_rand_loguniform(plot):
 def test_rand_inv_loguniform(plot):
     # Calculates that the
 
-    v2_min = 0.5
     v2_max = 1e3
     v2_min = 1e-3
     n_samples = 1000
@@ -217,8 +216,8 @@ def test_rand_inv_loguniform(plot):
             "method": "random",
             "parameters": {
                 "v2": {
-                    "min": v2_min,
-                    "max": v2_max,
+                    "min": np.log(v2_min),
+                    "max": np.log(v2_max),
                     "distribution": "inv_log_uniform",
                 },
             },

--- a/tests/test_random_search.py
+++ b/tests/test_random_search.py
@@ -208,7 +208,8 @@ def test_rand_inv_loguniform(plot):
     # Calculates that the
 
     v2_min = 0.5
-    v2_max = 1.0
+    v2_max = 1e3
+    v2_min = 1e-3
     n_samples = 1000
 
     sweep_config_2params = SweepConfig(

--- a/tests/test_random_search.py
+++ b/tests/test_random_search.py
@@ -204,6 +204,48 @@ def test_rand_loguniform(plot):
     assert pred_samples.max() <= v2_max
 
 
+def test_rand_inv_loguniform(plot):
+    # Calculates that the
+
+    v2_min = 0.5
+    v2_max = 1.0
+    n_samples = 1000
+
+    sweep_config_2params = SweepConfig(
+        {
+            "method": "random",
+            "parameters": {
+                "v2": {
+                    "min": v2_min,
+                    "max": v2_max,
+                    "distribution": "inv_log_uniform",
+                },
+            },
+        }
+    )
+
+    runs = []
+    for i in range(n_samples):
+        suggestion = next_run(sweep_config_2params, runs)
+        runs.append(suggestion)
+
+    pred_samples = np.asarray([run.config["v2"]["value"] for run in runs])
+    true_samples = np.random.uniform(np.log(1/v2_max), np.log(1/v2_min), size=n_samples)
+    true_samples = np.exp(true_samples)
+    true_samples = 1/true_samples
+
+    # the lhs needs to be >= 0 because
+    bins = np.logspace(np.log10(v2_min), np.log10(v2_max), 10)
+
+    if plot:
+        plot_two_distributions(true_samples, pred_samples, bins, xscale="log")
+
+    check_that_samples_are_from_the_same_distribution(pred_samples, true_samples, bins)
+
+    assert pred_samples.min() >= v2_min
+    assert pred_samples.max() <= v2_max
+
+
 @pytest.mark.parametrize("q", [0.1, 1, 10])
 def test_rand_q_lognormal(q, plot):
 


### PR DESCRIPTION
Adding inverse log uniform distribution for sampling. This distribution is commonly used for sampling values for momentum.

The min and max parameters of this distribution specified in the sweep config are the true min and max of the samples, not the logarithm of the min/max as it is with the log uniform distribution