### PR TITLE
Remove <1.21 requirement for numpy and bump mypy to >=0.931

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,10 +81,49 @@ jobs:
           name: Run tests
           command: pip install tox==3.24.0 && tox -e py39
     resource_class: large
-  linters:
+  linters36:
+    executor:
+      name: python/default
+      tag: "3.6"
+    steps:
+      - checkout
+      - run:
+          name: Install dependencies
+          command: pip install -r requirements.dev.txt
+      - run:
+          pre-commit run --all-files
+      - run:
+          mypy --ignore-missing-imports --scripts-are-modules .
+  linters37:
+    executor:
+      name: python/default
+      tag: "3.7"
+    steps:
+      - checkout
+      - run:
+          name: Install dependencies
+          command: pip install -r requirements.dev.txt
+      - run:
+          pre-commit run --all-files
+      - run:
+          mypy --ignore-missing-imports --scripts-are-modules .
+  linters38:
     executor:
       name: python/default
       tag: "3.8"
+    steps:
+      - checkout
+      - run:
+          name: Install dependencies
+          command: pip install -r requirements.dev.txt
+      - run:
+          pre-commit run --all-files
+      - run:
+          mypy --ignore-missing-imports --scripts-are-modules .
+  linters39:
+    executor:
+      name: python/default
+      tag: "3.9"
     steps:
       - checkout
       - run:
@@ -102,4 +141,7 @@ workflows:
       - linux37
       - linux38
       - linux39
-      - linters
+      - linters36
+      - linters37
+      - linters38
+      - linters39

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,2 +1,6 @@
 -r requirements.txt
--r requirements.test.txt
+pre-commit==2.12.0
+black==20.8b1
+flake8==3.9.1
+types-PyYAML==5.4.3
+mypy>=0.931

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -1,12 +1,8 @@
+-r requirements.dev.txt
 tox>=3.24.0
 pytest==6.2.3
 pytest-cov==2.11.1
-pre-commit==2.12.0
-black==20.8b1
-flake8==3.9.1
 pytest-randomly==3.8.0
 matplotlib>=3
 pytest-xdist>=2.2.1
 pytest-profiling>=1.7.0
-types-PyYAML==5.4.3
-mypy>=0.931

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -9,4 +9,4 @@ matplotlib>=3
 pytest-xdist>=2.2.1
 pytest-profiling>=1.7.0
 types-PyYAML==5.4.3
-mypy==0.910
+mypy>=0.931

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy>=1.15,<1.21
+numpy>=1.15
 scipy>=1.5.4
 PyYAML
 scikit_learn==0.24.1

--- a/src/sweeps/run.py
+++ b/src/sweeps/run.py
@@ -107,7 +107,7 @@ class SweepRun(BaseModel):
             The maximum or minimum metric.
         """
 
-        cmp_func = np.max if kind == "maximum" else np.min
+        cmp_func = max if kind == "maximum" else min
         try:
             summary_metric = [self.summary_metric(metric_name)]
         except KeyError:

--- a/tests/test_bayes_search.py
+++ b/tests/test_bayes_search.py
@@ -1,6 +1,6 @@
 import os
 import json
-from typing import Callable, Optional, Tuple, Iterable, Dict, Union
+from typing import Callable, Optional, Tuple, Iterable, Dict
 
 import pytest
 import numpy as np
@@ -30,7 +30,7 @@ def run_bayes_search(
     improvement: floating = 0.1,
     num_iterations: integer = 20,
     optimium: Optional[Dict[str, floating]] = None,
-    atol: Optional[Union[Dict[str, floating], floating]] = 0.2,
+    atol: float = 0.2,
 ):
 
     metric_name = config["metric"]["name"]
@@ -99,7 +99,7 @@ def run_iterations(
     x_init: Optional[ArrayLike] = None,
     improvement: floating = 0.1,
     optimium: Optional[ArrayLike] = None,
-    atol: Optional[ArrayLike] = 0.2,
+    atol: float = 0.2,
     chunk_size: integer = 1,
 ) -> Tuple[ArrayLike, ArrayLike]:
 
@@ -134,8 +134,10 @@ def run_iterations(
                 )
             )
 
+        assert sample_X is not None
+        sample_X = np.asarray(sample_X, dtype=np.float64)
+
         X = np.append(X, sample_X, axis=0)
-        print(X[np.argmin(y)])
         y = np.array([f(x) for x in X]).flatten()
 
     if optimium is not None:

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist = py{36,37,38,39}
 
 [testenv:py{36,37,38,39}]
 deps =
-    -r{toxinidir}/requirements.dev.txt
+    -r{toxinidir}/requirements.test.txt
 
 install_command =
     pip install {opts} {packages}


### PR DESCRIPTION
This PR removes the `requirements.txt` requirement that the numpy version be less than 1.21. There was a mypy issue in numpy 1.21+ the type `Union[float, np.floating]` was not recognized as `SupportsLessThanT` which caused mypy to fail sometimes. This has been fixed in mypy 0.931 so I bumped the mypy requirement to that version. I also added some more circleci checks to run mypy for python 3.6-3.9 instead of just 3.8. This catches more type system issues, including a few in `test_bayes_search.py` that I addressed here.