### PR TITLE
[WB-8039] Accept categorical probabilities in grid search 

### DIFF
--- a/src/sweeps/config/cfg.py
+++ b/src/sweeps/config/cfg.py
@@ -6,7 +6,12 @@ from pathlib import Path
 from typing import Union, Dict, List
 
 import jsonschema
-from .schema import validator, fill_validate_schema, validate_min_max
+from .schema import (
+    validate_categorical_prob,
+    validator,
+    fill_validate_schema,
+    validate_min_max,
+)
 from copy import deepcopy
 
 
@@ -32,6 +37,11 @@ def schema_violations_from_proposed_config(config: Dict) -> List[str]:
                 validate_min_max(parameter_name, parameter_dict)
             except ValueError as e:
                 schema_violation_messages.append(e.args[0])
+            try:
+                validate_categorical_prob(parameter_name, parameter_dict)
+            except ValueError as e:
+                schema_violation_messages.append(e.args[0])
+
     return schema_violation_messages
 
 

--- a/src/sweeps/config/schema.json
+++ b/src/sweeps/config/schema.json
@@ -20,7 +20,8 @@
         "probabilities": {
           "type": "array",
           "items": {
-            "type": "number"
+            "type": "number",
+            "minimum": 0
           },
           "description": "Probability of each value"
         },

--- a/src/sweeps/config/schema.json
+++ b/src/sweeps/config/schema.json
@@ -19,6 +19,9 @@
         },
         "probabilities": {
           "type": "array",
+          "items": {
+            "type": "number"
+          },
           "description": "Probability of each value"
         },
         "distribution": {

--- a/src/sweeps/config/schema.json
+++ b/src/sweeps/config/schema.json
@@ -17,8 +17,31 @@
           "description": "Discrete values",
           "minItems": 1
         },
+        "distribution": {
+          "enum": [
+            "categorical"
+          ],
+          "default": "categorical"
+        }
+      },
+      "additionalProperties": false
+    },
+    "param_categorical_w_probabilities": {
+      "type": "object",
+      "description": "A categorical parameter with allowed values and corresponding probabilities",
+      "required": [
+        "values",
+        "probabilities"
+      ],
+      "properties": {
+        "values": {
+          "type": "array",
+          "description": "Discrete values",
+          "minItems": 1
+        },
         "probabilities": {
           "type": "array",
+          "minItems": 1,
           "items": {
             "type": "number",
             "minimum": 0
@@ -27,9 +50,9 @@
         },
         "distribution": {
           "enum": [
-            "categorical"
+            "categorical_w_probabilities"
           ],
-          "default": "categorical"
+          "default": "categorical_w_probabilities"
         }
       },
       "additionalProperties": false
@@ -470,6 +493,9 @@
         },
         {
           "$ref": "#/definitions/param_categorical"
+        },
+        {
+          "$ref": "#/definitions/param_categorical_w_probabilities"
         },
         {
           "$ref": "#/definitions/param_int_uniform"

--- a/src/sweeps/config/schema.json
+++ b/src/sweeps/config/schema.json
@@ -17,6 +17,10 @@
           "description": "Discrete values",
           "minItems": 1
         },
+        "probabilities": {
+          "type": "array",
+          "description": "Probability of each value"
+        },
         "distribution": {
           "enum": [
             "categorical"

--- a/src/sweeps/config/schema.py
+++ b/src/sweeps/config/schema.py
@@ -1,6 +1,7 @@
 import json
 import jsonref
 import jsonschema
+import numpy as np
 from jsonschema import Draft7Validator, validators
 
 from pathlib import Path
@@ -113,7 +114,7 @@ def validate_categorical_prob(parameter_name: str, parameter_config: Dict) -> No
                 f" and probabilities {parameter_config['probabilities']} are not "
                 f"the same length"
             )
-        if sum(parameter_config["probabilities"]) != 1.0:
+        if not np.isclose(sum(parameter_config["probabilities"]), 1.0):
             raise ValueError(
                 f"Parameter {parameter_name}: Probabilities "
                 f"{parameter_config['probabilities']} do not sum to 1"

--- a/src/sweeps/config/schema.py
+++ b/src/sweeps/config/schema.py
@@ -7,8 +7,6 @@ from pathlib import Path
 from typing import Dict, Optional, Tuple
 from copy import deepcopy
 
-from pytest import param
-
 sweep_config_jsonschema_fname = Path(__file__).parent / "schema.json"
 with open(sweep_config_jsonschema_fname, "r") as f:
     sweep_config_jsonschema = json.load(f)

--- a/src/sweeps/config/schema.py
+++ b/src/sweeps/config/schema.py
@@ -7,6 +7,8 @@ from pathlib import Path
 from typing import Dict, Optional, Tuple
 from copy import deepcopy
 
+from pytest import param
+
 sweep_config_jsonschema_fname = Path(__file__).parent / "schema.json"
 with open(sweep_config_jsonschema_fname, "r") as f:
     sweep_config_jsonschema = json.load(f)
@@ -102,6 +104,21 @@ def validate_min_max(parameter_name: str, parameter_config: Dict) -> None:
             raise ValueError(
                 f'{parameter_name}: min {parameter_config["min"]} is not '
                 f'less than max {parameter_config["max"]}'
+            )
+
+
+def validate_categorical_prob(parameter_name: str, parameter_config: Dict) -> None:
+    if "values" in parameter_config and "probabilities" in parameter_config:
+        if len(parameter_config["values"]) != len(parameter_config["probabilities"]):
+            raise ValueError(
+                f"Parameter {parameter_name}: values {parameter_config['values']}"
+                f" and probabilities {parameter_config['probabilities']} are not "
+                f"the same length"
+            )
+        if sum(parameter_config["probabilities"]) != 1.0:
+            raise ValueError(
+                f"Parameter {parameter_name}: Probabilities "
+                f"{parameter_config['probabilities']} do not sum to 1"
             )
 
 

--- a/src/sweeps/grid_search.py
+++ b/src/sweeps/grid_search.py
@@ -63,7 +63,8 @@ def grid_search_next_runs(
         ]:
             raise ValueError(
                 f"Parameter {p.name} is a disallowed type with grid search. Grid search requires all parameters "
-                f"to be categorical, constant, int_uniform, or q_uniform."
+                f"to be categorical, constant, int_uniform, or q_uniform. Specification of probabilities for "
+                f"categorical parameters is disallowed in grid search"
             )
 
     # convert bounded int_uniform and q_uniform parameters to categorical parameters

--- a/src/sweeps/params.py
+++ b/src/sweeps/params.py
@@ -97,7 +97,7 @@ class HyperParameter:
         Args:
              x: Parameter values to calculate the CDF for. Can be scalar or 1-d.
         Returns:
-            Probability that a random sample of this hyperparameter will be less 
+            Probability that a random sample of this hyperparameter will be less
             than or equal to x.
         """
         if self.type == HyperParameter.CONSTANT:
@@ -176,9 +176,7 @@ class HyperParameter:
                 return self.config["values"][np.argmin(x >= cdf, axis=-1)]
             else:
                 return [
-                    self.config["values"][i] for i in [
-                        np.argmin(cdf >= p) for p in x 
-                    ]
+                    self.config["values"][i] for i in [np.argmin(cdf >= p) for p in x]
                 ]
 
         elif self.type == HyperParameter.INT_UNIFORM:

--- a/src/sweeps/params.py
+++ b/src/sweeps/params.py
@@ -18,6 +18,7 @@ class HyperParameter:
 
     CONSTANT = "param_single_value"
     CATEGORICAL = "param_categorical"
+    CATEGORICAL_PROB = "param_categorical_w_probabilities"
     INT_UNIFORM = "param_int_uniform"
     UNIFORM = "param_uniform"
     LOG_UNIFORM = "param_loguniform"
@@ -104,8 +105,8 @@ class HyperParameter:
             return np.zeros_like(x)
         elif self.type == HyperParameter.CATEGORICAL:
             # NOTE: Indices expected for categorical parameters, not values.
-            if not self.config.get("probabilities"):
-                return stats.randint.cdf(x, 0, len(self.config["values"]))
+            return stats.randint.cdf(x, 0, len(self.config["values"]))
+        elif self.type == HyperParameter.CATEGORICAL_PROB:
             return np.cumsum(self.config["probabilities"])[x]
         elif self.type == HyperParameter.INT_UNIFORM:
             return stats.randint.cdf(x, self.config["min"], self.config["max"] + 1)
@@ -159,17 +160,17 @@ class HyperParameter:
         if self.type == HyperParameter.CONSTANT:
             return self.config["value"]
         elif self.type == HyperParameter.CATEGORICAL:
-            if not self.config.get("probabilities"):
-                # Samples uniformly over the values
-                retval = [
-                    self.config["values"][i]
-                    for i in np.atleast_1d(
-                        stats.randint.ppf(x, 0, len(self.config["values"])).astype(int)
-                    ).tolist()
-                ]
-                if np.isscalar(x):
-                    return retval[0]
-                return retval
+            # Samples uniformly over the values
+            retval = [
+                self.config["values"][i]
+                for i in np.atleast_1d(
+                    stats.randint.ppf(x, 0, len(self.config["values"])).astype(int)
+                ).tolist()
+            ]
+            if np.isscalar(x):
+                return retval[0]
+            return retval
+        elif self.type == HyperParameter.CATEGORICAL_PROB:
             # Samples by specified categorical distribution if specified
             cdf = np.cumsum(self.config["probabilities"])
             if np.isscalar(x):
@@ -178,7 +179,6 @@ class HyperParameter:
                 return [
                     self.config["values"][i] for i in [np.argmin(cdf >= p) for p in x]
                 ]
-
         elif self.type == HyperParameter.INT_UNIFORM:
             return (
                 stats.randint.ppf(x, self.config["min"], self.config["max"] + 1)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,6 @@
 import pytest
 import jsonschema
-from sweeps import config
+from sweeps import config, grid_search
 
 
 def test_invalid_sweep_config_nonuniform_array_elements_categorical():
@@ -67,3 +67,13 @@ def test_irregular_probs():
     }
     with pytest.raises(jsonschema.ValidationError):
         _ = config.SweepConfig(invalid_config)
+
+
+def test_categorical_prob_grid():
+    invalid_config = {
+        "method": "grid",
+        "parameters": {"v1": {"values": [1, 2, 3], "probabilities": [0.2, 0.2, 0.6]}},
+    }
+    with pytest.raises(ValueError):
+        sweep_config = config.SweepConfig(invalid_config)
+        grid_search.grid_search_next_runs([], sweep_config)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -47,3 +47,23 @@ def test_missing_parameters_section():
 
     warnings = config.schema_violations_from_proposed_config(invalid_config)
     assert len(warnings) == 1
+
+
+def test_wrong_prob_length():
+    invalid_config = {
+        "method": "random",
+        "parameters": {
+            "v1": {"values": [1, 2, 3], "probabilities": [0.1, 0.2, 0.3, 0.4]}
+        },
+    }
+    with pytest.raises(jsonschema.ValidationError):
+        _ = config.SweepConfig(invalid_config)
+
+
+def test_irregular_probs():
+    invalid_config = {
+        "method": "random",
+        "parameters": {"v1": {"values": [1, 2, 3], "probabilities": [0.1, 0.2, 0.3]}},
+    }
+    with pytest.raises(jsonschema.ValidationError):
+        _ = config.SweepConfig(invalid_config)

--- a/tests/test_random_search.py
+++ b/tests/test_random_search.py
@@ -75,6 +75,33 @@ def plot_two_distributions(
     fig.savefig(test_results_dir / fname)
 
 
+@pytest.mark.parametrize(
+    "values,probs",
+    [
+        (list(range(5)), [0.2, 0.2, 0.2, 0.2, 0.2]),
+        (list(range(3)), [0.5, 0.0, 0.5]),
+        (list(range(5)), [0.1, 0.25, 0.15, 0.2, 0.3]),
+    ],
+)
+def test_rand_categorical(values, probs):
+    n_samples = 1000
+    HyperParameter("categorical", dict(values=values, probabilities=probs))
+    sweep_config_2params = SweepConfig(
+        {
+            "method": "random",
+            "parameters": {"v1": {"values": values, "probabilities": probs}},
+        }
+    )
+    runs = []
+    for i in range(n_samples):
+        suggestion = next_run(sweep_config_2params, runs)
+        runs.append(suggestion)
+    pred_samples = [run.config["v1"]["value"] for run in runs]
+    for i, v in enumerate(values):
+        expected = n_samples * probs[i]
+        assert abs(pred_samples.count(v) - expected) <= 3 * np.sqrt(expected)
+
+
 def test_rand_uniform(plot):
 
     v1_min = 3.0

--- a/tests/test_random_search.py
+++ b/tests/test_random_search.py
@@ -85,7 +85,7 @@ def plot_two_distributions(
 )
 def test_rand_categorical(values, probs):
     n_samples = 1000
-    HyperParameter("categorical", dict(values=values, probabilities=probs))
+
     sweep_config_2params = SweepConfig(
         {
             "method": "random",


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-8039

This PR introduces the option to explicitly specify the distribution for categorical random variables. In the definition of a categorical parameter within the sweep config, the `probabilities` key can be added with an array of numbers; the array must be in equal in length to the cardinality of the variable and the values in the array must sum to 1 (each value must be >= 0).

The choice to make the array sum to 1 is not necessary, we could instead allow the user to provide an array of positive numbers and then normalize it ourselves.

Some constraints on the probability array (e.g. summing to 1, equal length to # values) are not expressible via the schema, so new checks have been added to cfg.py

This PR adds tests both for the validation of the new sweep config features and testing that the samples from custom categorical random variables match the spec. The sampling test is implemented by checking that number of samples drawn for a particular value is in the range of x +- 2(x^0.5) where x is the expected number of samples for that particular value per the parameter config. This can be modified to be more stringent, but the number of samples may need to increase for the test to not become overly flaky.