### PR TITLE
[WB-8045][WB-1444] Allow Specification of Limit Values for Logarithmic Distributions

### DIFF
--- a/src/sweeps/config/cfg.py
+++ b/src/sweeps/config/cfg.py
@@ -11,6 +11,7 @@ from .schema import (
     validator,
     fill_validate_schema,
     validate_min_max,
+    check_for_deprecated_distributions,
 )
 from copy import deepcopy
 
@@ -39,6 +40,10 @@ def schema_violations_from_proposed_config(config: Dict) -> List[str]:
                 schema_violation_messages.append(e.args[0])
             try:
                 validate_categorical_prob(parameter_name, parameter_dict)
+            except ValueError as e:
+                schema_violation_messages.append(e.args[0])
+            try:
+                check_for_deprecated_distributions(parameter_name, parameter_dict)
             except ValueError as e:
                 schema_violation_messages.append(e.args[0])
 

--- a/src/sweeps/config/cfg.py
+++ b/src/sweeps/config/cfg.py
@@ -44,7 +44,7 @@ def schema_violations_from_proposed_config(config: Dict) -> List[str]:
                 schema_violation_messages.append(e.args[0])
             try:
                 check_for_deprecated_distributions(parameter_name, parameter_dict)
-            except ValueError as e:
+            except (ValueError, jsonschema.ValidationError) as e:
                 schema_violation_messages.append(e.args[0])
 
     return schema_violation_messages

--- a/src/sweeps/config/schema.json
+++ b/src/sweeps/config/schema.json
@@ -337,7 +337,7 @@
         },
         "distribution": {
           "enum": [
-            "loguniform"
+            "log_uniform_values"
           ]
         }
       },
@@ -388,7 +388,7 @@
         },
         "distribution": {
           "enum": [
-            "inv_loguniform"
+            "inv_log_uniform_values"
           ]
         }
       },
@@ -480,7 +480,7 @@
         },
         "distribution": {
           "enum": [
-            "q_loguniform"
+            "q_log_uniform_values"
           ]
         }
       },

--- a/src/sweeps/config/schema.json
+++ b/src/sweeps/config/schema.json
@@ -613,6 +613,15 @@
         },
         {
           "$ref": "#/definitions/param_single_value"
+        },
+        {
+          "$ref": "#/definitions/param_inv_loguniform_v2"
+        },
+        {
+          "$ref": "#/definitions/param_loguniform_v2"
+        },
+        {
+          "$ref": "#/definitions/param_qloguniform_v2"
         }
       ]
     },

--- a/src/sweeps/config/schema.json
+++ b/src/sweeps/config/schema.json
@@ -317,6 +317,32 @@
       },
       "additionalProperties": false
     },
+    "param_loguniform_v2": {
+      "type": "object",
+      "description": "log uniform distribution.",
+      "required": [
+        "distribution",
+        "max",
+        "min"
+      ],
+      "properties": {
+        "min": {
+          "description": "float",
+          "type": "number",
+          "exclusiveMinimum": 0.0
+        },
+        "max": {
+          "description": "float",
+          "type": "number"
+        },
+        "distribution": {
+          "enum": [
+            "loguniform"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
     "param_inv_loguniform": {
       "type": "object",
       "description": "inverse log uniform distribution",
@@ -337,6 +363,32 @@
         "distribution": {
           "enum": [
             "inv_log_uniform"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "param_inv_loguniform_v2": {
+      "type": "object",
+      "description": "inverse log uniform distribution",
+      "required": [
+        "distribution",
+        "max",
+        "min"
+      ],
+      "properties": {
+        "min": {
+          "description": "float",
+          "type": "number",
+          "exclusiveMinimum": 0.0
+        },
+        "max": {
+          "description": "float",
+          "type": "number"
+        },
+        "distribution": {
+          "enum": [
+            "inv_loguniform"
           ]
         }
       },
@@ -397,6 +449,38 @@
         "distribution": {
           "enum": [
             "q_log_uniform"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "param_qloguniform_v2": {
+      "type": "object",
+      "description": "quantized log uniform distribution",
+      "required": [
+        "distribution",
+        "max",
+        "min"
+      ],
+      "properties": {
+        "min": {
+          "description": "float",
+          "type": "number",
+          "exclusiveMinimum": 0.0
+        },
+        "max": {
+          "description": "float",
+          "type": "number"
+        },
+        "q": {
+          "type": "number",
+          "default": 1.0,
+          "description": "Quantization parameter for quantized distributions",
+          "exclusiveMinimum": 0
+        },
+        "distribution": {
+          "enum": [
+            "q_loguniform"
           ]
         }
       },

--- a/src/sweeps/config/schema.py
+++ b/src/sweeps/config/schema.py
@@ -121,6 +121,20 @@ def validate_categorical_prob(parameter_name: str, parameter_config: Dict) -> No
             )
 
 
+def check_for_deprecated_distributions(
+    parameter_name: str, parameter_config: Dict
+) -> None:
+    from ..params import HyperParameter, PARAM_DEPRECATION_MAP
+
+    param = HyperParameter(
+        parameter_name, parameter_config
+    )  # will raise if parameter config is malformed
+
+    # check if type is deprecated
+    if param.type in PARAM_DEPRECATION_MAP:
+        raise ValueError(f"{parameter_name} {PARAM_DEPRECATION_MAP[param.type]}")
+
+
 def fill_validate_metric(d: Dict) -> Dict:
     d = deepcopy(d)
 

--- a/src/sweeps/params.py
+++ b/src/sweeps/params.py
@@ -155,11 +155,26 @@ class HyperParameter:
             return stats.uniform.cdf(
                 np.log(x), self.config["min"], self.config["max"] - self.config["min"]
             )
+        elif (
+            self.type == HyperParameter.LOG_UNIFORM_V2
+            or self.type == HyperParameter.Q_LOG_UNIFORM_V2
+        ):
+            return stats.uniform.cdf(
+                np.log(x),
+                np.log(self.config["min"]),
+                np.log(self.config["max"]) - np.log(self.config["min"]),
+            )
         elif self.type == HyperParameter.INV_LOG_UNIFORM_V1:
             return 1 - stats.uniform.cdf(
                 np.log(1 / x),
                 self.config["min"],
                 self.config["max"] - self.config["min"],
+            )
+        elif self.type == HyperParameter.INV_LOG_UNIFORM_V2:
+            return 1 - stats.uniform.cdf(
+                np.log(1 / x),
+                -np.log(self.config["max"]),
+                np.abs(np.log(self.config["max"]) - np.log(self.config["min"])),
             )
         elif self.type == HyperParameter.NORMAL or self.type == HyperParameter.Q_NORMAL:
             return stats.norm.cdf(x, loc=self.config["mu"], scale=self.config["sigma"])

--- a/src/sweeps/params.py
+++ b/src/sweeps/params.py
@@ -33,6 +33,10 @@ def inv_log_uniform_v1_ppf(x: ArrayLike, min, max):
     )
 
 
+def loguniform_v1_ppf(x: ArrayLike, min, max):
+    return np.exp(stats.uniform.ppf(x, min, max - min))
+
+
 class HyperParameter:
 
     CONSTANT = "param_single_value"
@@ -227,10 +231,10 @@ class HyperParameter:
             else:
                 return ret_val
         elif self.type == HyperParameter.LOG_UNIFORM_V1:
-            return np.exp(
-                stats.uniform.ppf(
-                    x, self.config["min"], self.config["max"] - self.config["min"]
-                )
+            return loguniform_v1_ppf(x, self.config["min"], self.config["max"])
+        elif self.type == HyperParameter.LOG_UNIFORM_V2:
+            return loguniform_v1_ppf(
+                x, np.log(self.config["min"]), np.log(self.config["max"])
             )
         elif self.type == HyperParameter.INV_LOG_UNIFORM_V1:
             return inv_log_uniform_v1_ppf(x, self.config["min"], self.config["max"])

--- a/tests/test_bayes_search.py
+++ b/tests/test_bayes_search.py
@@ -68,7 +68,7 @@ def run_bayes_search(
     "x",
     [
         {"distribution": "normal", "mu": 2, "sigma": 4},
-        {"distribution": "log_uniform", "min": -2, "max": 3},
+        {"distribution": "loguniform", "min": np.exp(-2), "max": np.exp(3)},
         {"min": 0.0, "max": 5.0},
         {"min": 0, "max": 5},
         {"distribution": "q_uniform", "min": 0.0, "max": 10.0, "q": 0.25},

--- a/tests/test_bayes_search.py
+++ b/tests/test_bayes_search.py
@@ -68,7 +68,7 @@ def run_bayes_search(
     "x",
     [
         {"distribution": "normal", "mu": 2, "sigma": 4},
-        {"distribution": "loguniform", "min": np.exp(-2), "max": np.exp(3)},
+        {"distribution": "log_uniform_values", "min": np.exp(-2), "max": np.exp(3)},
         {"min": 0.0, "max": 5.0},
         {"min": 0, "max": 5},
         {"distribution": "q_uniform", "min": 0.0, "max": 10.0, "q": 0.25},

--- a/tests/test_random_search.py
+++ b/tests/test_random_search.py
@@ -239,6 +239,92 @@ def test_rand_inv_loguniform(plot):
     v2_max = 1e20
 
     # limits for sweep config are in log(1/x) space
+    limit_min = np.log(1 / v2_max)
+    limit_max = np.log(1 / v2_min)
+    n_samples = 20000
+
+    param_config = {
+        "min": limit_min,
+        "max": limit_max,
+        "distribution": "inv_log_uniform",
+    }
+
+    sweep_config_2params = SweepConfig(
+        {
+            "method": "random",
+            "parameters": {
+                "v2": param_config,
+            },
+        }
+    )
+
+    runs = []
+    for i in range(n_samples):
+        suggestion = next_run(sweep_config_2params, runs)
+        runs.append(suggestion)
+
+    pred_samples = np.asarray([run.config["v2"]["value"] for run in runs])
+    true_samples = np.random.uniform(limit_min, limit_max, size=n_samples)
+    true_samples = np.exp(true_samples)
+    true_samples = 1 / true_samples
+
+    # the lhs needs to be >= 0 because
+    bins = np.logspace(np.log10(v2_min), np.log10(v2_max), 10)
+
+    if plot:
+        plot_two_distributions(true_samples, pred_samples, bins, xscale="log")
+
+    check_that_samples_are_from_the_same_distribution(pred_samples, true_samples, bins)
+
+    assert pred_samples.min() >= v2_min
+    assert pred_samples.max() <= v2_max
+
+    # use more bins to check that the CDF is correct
+    bins = np.logspace(np.log10(v2_min), np.log10(v2_max), 100)
+    n, _ = np.histogram(true_samples, bins=bins)
+    cdf_empirical = np.cumsum(n) / np.sum(n)
+    bin_centers = 0.5 * (bins[1:] + bins[:-1])
+
+    hyperparameter = HyperParameter("inv_log_uniform", param_config)
+    cdf_pred = hyperparameter.cdf(bin_centers)
+
+    if plot:
+        import matplotlib.pyplot as plt
+        import inspect
+
+        fig, ax = plt.subplots()
+        ax.step(
+            bin_centers,
+            cdf_empirical,
+            label="true",
+        )
+        ax.step(
+            bin_centers,
+            cdf_pred,
+            label="pred",
+        )
+        ax.legend()
+        ax.set_xscale("log")
+        ax.tick_params(which="both", axis="both", direction="in")
+        current_test = os.environ.get("PYTEST_CURRENT_TEST")
+        if current_test is None:
+            current_test = inspect.stack()[1].function
+        else:
+            current_test = current_test.split(":")[-1].split(" ")[0]
+        fname = f"{current_test}.cdf.pdf"
+        fig.savefig(test_results_dir / fname)
+
+    # assert that the cdfs are within 0.03 everywhere
+    np.testing.assert_array_less(np.abs(cdf_pred - cdf_empirical), 0.03)
+
+
+def test_rand_inv_loguniform_values(plot):
+
+    # samples of v2 are between 1e-15 and 1e20
+    v2_min = 1e-15
+    v2_max = 1e20
+
+    # limits for sweep config are in log(1/x) space
     limit_min = v2_min
     limit_max = v2_max
     n_samples = 20000

--- a/tests/test_random_search.py
+++ b/tests/test_random_search.py
@@ -198,18 +198,16 @@ def test_rand_loguniform(plot):
     v2_max = 100
     n_samples = 1000
 
-    sweep_config_2params = SweepConfig(
-        {
-            "method": "random",
-            "parameters": {
-                "v2": {
-                    "min": np.log(v2_min),
-                    "max": np.log(v2_max),
-                    "distribution": "log_uniform",
-                },
+    sweep_config_2params = {
+        "method": "random",
+        "parameters": {
+            "v2": {
+                "min": np.log(v2_min),
+                "max": np.log(v2_max),
+                "distribution": "log_uniform",
             },
-        }
-    )
+        },
+    }
 
     runs = []
     for i in range(n_samples):
@@ -290,14 +288,12 @@ def test_rand_inv_loguniform(plot):
         "distribution": "inv_log_uniform",
     }
 
-    sweep_config_2params = SweepConfig(
-        {
-            "method": "random",
-            "parameters": {
-                "v2": param_config,
-            },
-        }
-    )
+    sweep_config_2params = {
+        "method": "random",
+        "parameters": {
+            "v2": param_config,
+        },
+    }
 
     runs = []
     for i in range(n_samples):
@@ -600,19 +596,17 @@ def test_rand_q_loguniform_values(q, plot):
 def test_rand_q_loguniform(q, plot):
 
     n_samples_pred = 1000
-    sweep_config_2params = SweepConfig(
-        {
-            "method": "random",
-            "parameters": {
-                "v1": {
-                    "distribution": "q_log_uniform",
-                    "min": np.log(0.1),
-                    "max": np.log(100),
-                    "q": q,
-                },
+    sweep_config_2params = {
+        "method": "random",
+        "parameters": {
+            "v1": {
+                "distribution": "q_log_uniform",
+                "min": np.log(0.1),
+                "max": np.log(100),
+                "q": q,
             },
-        }
-    )
+        },
+    }
 
     runs = []
     for i in range(n_samples_pred):

--- a/tests/test_random_search.py
+++ b/tests/test_random_search.py
@@ -287,7 +287,7 @@ def test_rand_inv_loguniform(plot):
     cdf_empirical = np.cumsum(n) / np.sum(n)
     bin_centers = 0.5 * (bins[1:] + bins[:-1])
 
-    hyperparameter = HyperParameter("inv_log_uniform", param_config)
+    hyperparameter = HyperParameter("inv_log_uniform_values", param_config)
     cdf_pred = hyperparameter.cdf(bin_centers)
 
     if plot:

--- a/tests/test_random_search.py
+++ b/tests/test_random_search.py
@@ -205,7 +205,7 @@ def test_rand_loguniform(plot):
                 "v2": {
                     "min": v2_min,
                     "max": v2_max,
-                    "distribution": "loguniform",
+                    "distribution": "log_uniform_values",
                 },
             },
         }
@@ -246,7 +246,7 @@ def test_rand_inv_loguniform(plot):
     param_config = {
         "min": limit_min,
         "max": limit_max,
-        "distribution": "inv_loguniform",
+        "distribution": "inv_log_uniform_values",
     }
 
     sweep_config_2params = SweepConfig(
@@ -264,7 +264,9 @@ def test_rand_inv_loguniform(plot):
         runs.append(suggestion)
 
     pred_samples = np.asarray([run.config["v2"]["value"] for run in runs])
-    true_samples = np.random.uniform(limit_min, limit_max, size=n_samples)
+    true_samples = np.random.uniform(
+        np.log(1 / limit_max), np.log(1 / limit_min), size=n_samples
+    )
     true_samples = np.exp(true_samples)
     true_samples = 1 / true_samples
 
@@ -436,7 +438,7 @@ def test_rand_q_loguniform(q, plot):
             "method": "random",
             "parameters": {
                 "v1": {
-                    "distribution": "q_loguniform",
+                    "distribution": "q_log_uniform_values",
                     "min": 0.1,
                     "max": 100,
                     "q": q,

--- a/tests/test_random_search.py
+++ b/tests/test_random_search.py
@@ -191,7 +191,7 @@ def test_rand_lognormal(plot):
     check_that_samples_are_from_the_same_distribution(pred_samples, true_samples, bins)
 
 
-def test_rand_loguniform(plot):
+def test_rand_loguniform_values(plot):
     # Calculates that the
 
     v2_min = 5.0
@@ -516,7 +516,7 @@ def test_rand_q_uniform(q, plot):
 
 
 @pytest.mark.parametrize("q", [0.1, 1, 10])
-def test_rand_q_loguniform(q, plot):
+def test_rand_q_loguniform_values(q, plot):
 
     n_samples_pred = 1000
     sweep_config_2params = SweepConfig(

--- a/tests/test_random_search.py
+++ b/tests/test_random_search.py
@@ -203,9 +203,9 @@ def test_rand_loguniform(plot):
             "method": "random",
             "parameters": {
                 "v2": {
-                    "min": np.log(v2_min),
-                    "max": np.log(v2_max),
-                    "distribution": "log_uniform",
+                    "min": v2_min,
+                    "max": v2_max,
+                    "distribution": "loguniform",
                 },
             },
         }
@@ -239,14 +239,14 @@ def test_rand_inv_loguniform(plot):
     v2_max = 1e20
 
     # limits for sweep config are in log(1/x) space
-    limit_min = np.log(1 / v2_max)
-    limit_max = np.log(1 / v2_min)
+    limit_min = v2_min
+    limit_max = v2_max
     n_samples = 20000
 
     param_config = {
         "min": limit_min,
         "max": limit_max,
-        "distribution": "inv_log_uniform",
+        "distribution": "inv_loguniform",
     }
 
     sweep_config_2params = SweepConfig(
@@ -436,9 +436,9 @@ def test_rand_q_loguniform(q, plot):
             "method": "random",
             "parameters": {
                 "v1": {
-                    "distribution": "q_log_uniform",
-                    "min": np.log(0.1),
-                    "max": np.log(100),
+                    "distribution": "q_loguniform",
+                    "min": 0.1,
+                    "max": 100,
                     "q": q,
                 },
             },

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -77,7 +77,7 @@ def test_minmax_type_inference():
     }
 
     violations = schema_violations_from_proposed_config(schema)
-    assert len(violations) == 1
+    assert len(violations) == 2
 
 
 @pytest.mark.parametrize("controller_type", ["cloud", "local", "invalid"])

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -160,3 +160,16 @@ def test_invalid_minmax_with_no_sweepconfig_validation():
 
     with pytest.raises(ValueError):
         fill_parameter("a", config["parameters"]["a"])
+
+
+@pytest.mark.parametrize(
+    "parameter_type", ["log_uniform", "q_log_uniform", "inv_log_uniform"]
+)
+def test_that_old_distributions_warn(parameter_type):
+    schema = {
+        "method": "random",
+        "parameters": {"a": {"min": 1, "max": 2, "distribution": parameter_type}},
+    }
+
+    violations = schema_violations_from_proposed_config(schema)
+    assert len(violations) > 0

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -173,3 +173,17 @@ def test_that_old_distributions_warn(parameter_type):
 
     violations = schema_violations_from_proposed_config(schema)
     assert len(violations) > 0
+
+
+@pytest.mark.parametrize(
+    "parameter_type",
+    ["log_uniform_values", "q_log_uniform_values", "inv_log_uniform_values"],
+)
+def test_that_minmax_validation_fails_on_loguniform_values_types(parameter_type):
+    schema = {
+        "method": "random",
+        "parameters": {"a": {"min": 2, "max": 1, "distribution": parameter_type}},
+    }
+
+    with pytest.raises(ValueError):
+        fill_parameter("a", schema["parameters"]["a"])


### PR DESCRIPTION
This PR adds three new distribution types to the sweep config spec: `log_uniform_values`, `inv_log_uniform_values`, and `q_log_uniform_values`. These allow you to specify the distribution sampling limits `min`, `max` as values instead of exponents. 

The old distributions will continue to be supported but we will remove them from the documentation. Additionally, users will receive a warning when they use one of these distributions that there are new distributions available and they should consider switching. 

Adds a bunch of tests to ensure the distributions are correct 

Fixes wandb/client#507