### PR TITLE
Abbreviation and case slop for extremum kind

### DIFF
--- a/src/sweeps/run.py
+++ b/src/sweeps/run.py
@@ -116,9 +116,9 @@ class SweepRun(BaseModel):
             The maximum or minimum metric.
         """
 
-        if kind.lower() in ["minimum", "min"]:
+        if kind.lower() in ["minimum", "min", "minimize"]:
             cmp_func = min
-        elif kind.lower() in ["maximum", "max"]:
+        elif kind.lower() in ["maximum", "max", "maximize"]:
             cmp_func = max
         else:
             raise ValueError(

--- a/src/sweeps/run.py
+++ b/src/sweeps/run.py
@@ -116,9 +116,9 @@ class SweepRun(BaseModel):
             The maximum or minimum metric.
         """
 
-        if kind.lower() in ['minimum', 'min']:
+        if kind.lower() in ["minimum", "min"]:
             cmp_func = min
-        elif kind.lower() in ['maximum', 'max']:
+        elif kind.lower() in ["maximum", "max"]:
             cmp_func = max
         else:
             raise ValueError(

--- a/src/sweeps/run.py
+++ b/src/sweeps/run.py
@@ -116,7 +116,14 @@ class SweepRun(BaseModel):
             The maximum or minimum metric.
         """
 
-        cmp_func = max if kind == "maximum" else min
+        if kind.lower() in ['minimum', 'min']:
+            cmp_func = min
+        elif kind.lower() in ['maximum', 'max']:
+            cmp_func = max
+        else:
+            raise ValueError(
+                f'Invalid extremum type {kind}, must be one of ["maximum", "minimum"]'
+            )
         try:
             summary_metric = [self.summary_metric(metric_name)]
         except KeyError:


### PR DESCRIPTION
This PR adds some abbreviation and case slop to the `SweepRun.metric_extremum` function's `kind` argument. It explicitly checks for the `kind` string to be either `maximum` or `minimum` or one of the common abbreviations `min` or `max`, throwing a `ValueError` if the value of `kind` isn't any of those. In the current implementation of this function, a function call of

```
run = SweepRun(...)
run.metric_extremum('a', 'max')
```

would return the minimum extremum, instead of the likely desired maximum. This does add a tiny bit of overhead over the current implementation of this function.

Edit: Seems like one of the tests has this exact failure case by sending a value of `kind="maximize"` instead of `kind="maximum"`. From [CI tests](https://app.circleci.com/pipelines/github/wandb/sweeps/363/workflows/b633f777-dbd5-4e7d-9c19-5f3445837dd6/jobs/1242/parallel-runs/0/steps/0-104).

```
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
tests/test_bayes_search.py:55: in run_bayes_search
    best_run = (min if opt_goal == "minimize" else max)(
tests/test_bayes_search.py:57: in <lambda>
    key=lambda run: run.metric_extremum(metric_name, opt_goal),
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

...

E           ValueError: Invalid extremum type maximize, must be one of ["maximum", "minimum"]

```