### PR TITLE
Fix/early termination bad config

### DIFF
--- a/src/sweeps/run.py
+++ b/src/sweeps/run.py
@@ -304,6 +304,10 @@ def stop_runs(
 
     if "early_terminate" not in sweep_config:
         raise ValueError('early terminate requires "early_terminate" section.')
+
+    if not isinstance(sweep_config["early_terminate"], Dict) or "type" not in sweep_config["early_terminate"]:
+        raise ValueError('early terminate must be a dict with fields "type"')
+
     et_type = sweep_config["early_terminate"]["type"]
 
     if et_type == "hyperband":

--- a/src/sweeps/run.py
+++ b/src/sweeps/run.py
@@ -305,8 +305,11 @@ def stop_runs(
     if "early_terminate" not in sweep_config:
         raise ValueError('early terminate requires "early_terminate" section.')
 
-    if not isinstance(sweep_config["early_terminate"], Dict) or "type" not in sweep_config["early_terminate"]:
-        raise ValueError('early terminate must be a dict with fields "type"')
+    if (
+        not isinstance(sweep_config["early_terminate"], Dict)
+        or "type" not in sweep_config["early_terminate"]
+    ):
+        raise ValueError('early terminate must be a dict with a "type" section')
 
     et_type = sweep_config["early_terminate"]["type"]
 

--- a/tests/test_hyperband_stopping.py
+++ b/tests/test_hyperband_stopping.py
@@ -407,6 +407,7 @@ def test_eta_3_max():
     to_stop = stop_runs(sweep_config, runs)
     assert to_stop == [runs[1], runs[-1]]
 
+
 def test_hyperband_runs_with_bad_config():
     # fixes https://sentry.io/share/issue/8fc67616a29a431f8f66ebbf40343ce1/
 
@@ -418,6 +419,7 @@ def test_hyperband_runs_with_bad_config():
     }
     with pytest.raises(ValueError):
         _ = stop_runs(invalid_config, [])
+
 
 def test_hyperband_runs_with_nan_metrics():
     # fixes https://sentry.io/share/issue/e6e002283c0447d6ac4defaf58a5d665/

--- a/tests/test_hyperband_stopping.py
+++ b/tests/test_hyperband_stopping.py
@@ -1,3 +1,4 @@
+import pytest
 from sweeps import stop_runs, next_run, RunState, SweepRun
 
 
@@ -406,6 +407,17 @@ def test_eta_3_max():
     to_stop = stop_runs(sweep_config, runs)
     assert to_stop == [runs[1], runs[-1]]
 
+def test_hyperband_runs_with_bad_config():
+    # fixes https://sentry.io/share/issue/8fc67616a29a431f8f66ebbf40343ce1/
+
+    invalid_config = {
+        "method": "bayes",
+        "metric": {"goal": "minimize", "name": "overall_eval_loss"},
+        "early_terminate": "hyperband",
+        "parameters": {"a": {"values": [1, 2, 3]}},
+    }
+    with pytest.raises(ValueError):
+        _ = stop_runs(invalid_config, [])
 
 def test_hyperband_runs_with_nan_metrics():
     # fixes https://sentry.io/share/issue/e6e002283c0447d6ac4defaf58a5d665/


### PR DESCRIPTION
Adds extra check to the `early_terminate` field in the config when stopping runs.

[WB-8208]
https://sentry.io/share/issue/8fc67616a29a431f8f66ebbf40343ce1/

[WB-8208]: https://wandb.atlassian.net/browse/WB-8208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ