### PR TITLE
add command flags to schema

### DIFF
--- a/src/sweeps/config/schema.json
+++ b/src/sweeps/config/schema.json
@@ -738,6 +738,10 @@
       "type": "array",
       "description": "Command used to launch the training script"
     },
+    "command_flags": {
+      "type": "array",
+      "description": "Which (if any) arguments passed into the command are flags."
+    },
     "name": {
       "type": "string",
       "description": "The name of the sweep, displayed in the W&B UI"


### PR DESCRIPTION
Adds `command_flags` section to sweeps configs. Combo PR with https://github.com/wandb/client/pull/3473

[WB-3809]


[WB-3809]: https://wandb.atlassian.net/browse/WB-3809?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ