### PR TITLE
[WB-1799][WB-1917]Nested Conditional Configs

### DIFF
--- a/src/sweeps/bayes_search.py
+++ b/src/sweeps/bayes_search.py
@@ -10,7 +10,7 @@ from .run import SweepRun, RunState, run_state_is_terminal
 from .params import (
     HyperParameter,
     HyperParameterSet,
-    validate_hyperparam_search_space_in_runs
+    validate_hyperparam_search_space_in_runs,
 )
 from sklearn import gaussian_process as sklearn_gaussian
 from scipy import stats as scipy_stats
@@ -483,8 +483,7 @@ def bayes_search_next_run(
 
     if validate:
         config = SweepConfig(config)
-
-    validate_hyperparam_search_space_in_runs(runs, config)
+    validate_hyperparam_search_space_in_runs(runs, config, throw_error=True)
 
     config = bayes_baseline_validate_and_fill(config)
 

--- a/src/sweeps/bayes_search.py
+++ b/src/sweeps/bayes_search.py
@@ -7,7 +7,11 @@ from typing import List, Tuple, Optional, Union, Dict
 from .config.cfg import SweepConfig
 from .config.schema import fill_validate_metric
 from .run import SweepRun, RunState, run_state_is_terminal
-from .params import HyperParameter, HyperParameterSet
+from .params import (
+    HyperParameter,
+    HyperParameterSet,
+    validate_hyperparam_search_space_in_runs
+)
 from sklearn import gaussian_process as sklearn_gaussian
 from scipy import stats as scipy_stats
 
@@ -479,6 +483,8 @@ def bayes_search_next_run(
 
     if validate:
         config = SweepConfig(config)
+
+    validate_hyperparam_search_space_in_runs(runs, config)
 
     config = bayes_baseline_validate_and_fill(config)
 

--- a/src/sweeps/config/schema.json
+++ b/src/sweeps/config/schema.json
@@ -55,7 +55,15 @@
       ],
       "properties": {
         "choices": {
-          "$ref": "#/definitions/param_dict"
+          "type": "object",
+          "description": "Possible choices to choose from",
+          "propertyNames": {
+            "pattern": "^^[A-Za-z_][A-Za-z0-9_.-]*$"
+          },
+          "additionalProperties": {
+            "$ref": "#/definitions/parameter"
+          },
+          "minProperties": 1
         }
       },
       "additionalProperties": false
@@ -604,12 +612,6 @@
     "parameter": {
       "anyOf": [
         {
-          "$ref": "#/definitions/param_dict"
-        },
-        {
-          "$ref": "#/definitions/param_choice"
-        },
-        {
           "$ref": "#/definitions/param_qbeta"
         },
         {
@@ -662,6 +664,12 @@
         },
         {
           "$ref": "#/definitions/param_qloguniform_v2"
+        },
+        {
+          "$ref": "#/definitions/param_dict"
+        },
+        {
+          "$ref": "#/definitions/param_choice"
         }
       ]
     },

--- a/src/sweeps/config/schema.json
+++ b/src/sweeps/config/schema.json
@@ -28,13 +28,21 @@
     },
     "param_dict": {
       "type": "object",
-      "description": "A categorical parameter with allowed values.",
+      "description": "A parameter dictionary containing other parameters.",
       "required": [
         "parameters"
       ],
       "properties": {
         "parameters": {
-          "$ref": "#/definitions/parameters"
+          "type": "object",
+          "description": "More config parameters",
+          "propertyNames": {
+            "pattern": "^^[A-Za-z_][A-Za-z0-9_.-]*$"
+          },
+          "additionalProperties": {
+            "$ref": "#/definitions/parameter"
+          },
+          "minProperties": 1
         }
       },
       "additionalProperties": false

--- a/src/sweeps/config/schema.json
+++ b/src/sweeps/config/schema.json
@@ -37,17 +37,6 @@
       },
       "minProperties": 1
     },
-    "param_choice": {
-      "type": "object",
-      "description": "Only one choice parameter per nest level will be picked.",
-      "propertyNames": {
-        "pattern": "^^[A-Za-z_][A-Za-z0-9_.-]*$"
-      },
-      "additionalProperties": {
-        "$ref": "#/definitions/parameter"
-      },
-      "minProperties": 1
-    },
     "param_categorical_w_probabilities": {
       "type": "object",
       "description": "A categorical parameter with allowed values and corresponding probabilities",

--- a/src/sweeps/config/schema.json
+++ b/src/sweeps/config/schema.json
@@ -26,6 +26,28 @@
       },
       "additionalProperties": false
     },
+    "param_dict": {
+      "type": "object",
+      "description": "A parameter dictionary which can contain other parameters.",
+      "propertyNames": {
+        "pattern": "^^[A-Za-z_][A-Za-z0-9_.-]*$"
+      },
+      "additionalProperties": {
+        "$ref": "#/definitions/parameter"
+      },
+      "minProperties": 1
+    },
+    "param_choice": {
+      "type": "object",
+      "description": "Only one choice parameter per nest level will be picked.",
+      "propertyNames": {
+        "pattern": "^^[A-Za-z_][A-Za-z0-9_.-]*$"
+      },
+      "additionalProperties": {
+        "$ref": "#/definitions/parameter"
+      },
+      "minProperties": 1
+    },
     "param_categorical_w_probabilities": {
       "type": "object",
       "description": "A categorical parameter with allowed values and corresponding probabilities",
@@ -569,6 +591,12 @@
     },
     "parameter": {
       "anyOf": [
+        {
+          "$ref": "#/definitions/param_dict"
+        },
+        {
+          "$ref": "#/definitions/param_choice"
+        },
         {
           "$ref": "#/definitions/param_qbeta"
         },

--- a/src/sweeps/config/schema.json
+++ b/src/sweeps/config/schema.json
@@ -28,14 +28,29 @@
     },
     "param_dict": {
       "type": "object",
-      "description": "A parameter dictionary which can contain other parameters.",
-      "propertyNames": {
-        "pattern": "^^[A-Za-z_][A-Za-z0-9_.-]*$"
+      "description": "A categorical parameter with allowed values.",
+      "required": [
+        "parameters"
+      ],
+      "properties": {
+        "parameters": {
+          "$ref": "#/definitions/parameters"
+        }
       },
-      "additionalProperties": {
-        "$ref": "#/definitions/parameter"
+      "additionalProperties": false
+    },
+    "param_choice": {
+      "type": "object",
+      "description": "A categorical parameter with allowed values.",
+      "required": [
+        "choices"
+      ],
+      "properties": {
+        "choices": {
+          "$ref": "#/definitions/param_dict"
+        }
       },
-      "minProperties": 1
+      "additionalProperties": false
     },
     "param_categorical_w_probabilities": {
       "type": "object",

--- a/src/sweeps/config/schema.py
+++ b/src/sweeps/config/schema.py
@@ -84,7 +84,7 @@ def fill_parameter(parameter_name: str, config: Dict) -> Optional[Tuple[str, Dic
                 subschema, format_checker=format_checker
             ).validate(config)
         except jsonschema.ValidationError:
-            continue   
+            continue
         else:
             if schema_name == "param_dict":
                 # If this is a nested param, don't fill any defaults, just pass the config forward

--- a/src/sweeps/config/schema.py
+++ b/src/sweeps/config/schema.py
@@ -86,9 +86,11 @@ def fill_parameter(parameter_name: str, config: Dict) -> Optional[Tuple[str, Dic
         except jsonschema.ValidationError:
             continue
         else:
-            if schema_name == "param_dict":
-                # If this is a nested param, don't fill any defaults, just pass the config forward
-                return "param_dict", config
+            if schema_name in ["param_dict", "param_choice"]:
+                # Don't try and fill default values for these
+                # just pass the config forward.
+                print(f"Skipping filling default values for {schema_name}, {config}")
+                return schema_name, config
             validate_min_max(parameter_name, config)
             filler = DefaultFiller(subschema, format_checker=format_checker)
             # this sets the defaults, modifying config inplace

--- a/src/sweeps/config/schema.py
+++ b/src/sweeps/config/schema.py
@@ -84,8 +84,11 @@ def fill_parameter(parameter_name: str, config: Dict) -> Optional[Tuple[str, Dic
                 subschema, format_checker=format_checker
             ).validate(config)
         except jsonschema.ValidationError:
-            continue
+            continue   
         else:
+            if schema_name == "param_dict":
+                # If this is a nested param, don't fill any defaults, just pass the config forward
+                return "param_dict", config
             validate_min_max(parameter_name, config)
             filler = DefaultFiller(subschema, format_checker=format_checker)
             # this sets the defaults, modifying config inplace

--- a/src/sweeps/grid_search.py
+++ b/src/sweeps/grid_search.py
@@ -8,7 +8,11 @@ import numpy as np
 
 from .config.cfg import SweepConfig
 from .run import SweepRun
-from .params import HyperParameter, HyperParameterSet
+from .params import (
+    HyperParameter,
+    HyperParameterSet,
+    validate_hyperparam_search_space_in_runs,
+)
 
 
 def yaml_hash(value: Any) -> str:
@@ -45,6 +49,7 @@ def grid_search_next_runs(
     # make sure the sweep config is valid
     if validate:
         sweep_config = SweepConfig(sweep_config)
+    validate_hyperparam_search_space_in_runs(runs, sweep_config)
 
     if sweep_config["method"] != "grid":
         raise ValueError("Invalid sweep configuration for grid_search_next_run.")

--- a/src/sweeps/params.py
+++ b/src/sweeps/params.py
@@ -212,7 +212,7 @@ class HyperParameter:
         """
         if np.any((x < 0.0) | (x > 1.0)):
             raise ValueError("Can't call ppf on value outside of [0,1]")
-        if self.type == HyperParameter.DICT:
+        elif self.type == HyperParameter.DICT:
             raise ValueError("Cannot calculate PDF for a param dict")
         elif self.type == HyperParameter.CONSTANT:
             return self.config["value"]
@@ -320,6 +320,8 @@ class HyperParameter:
         return self.ppf(random.uniform(0.0, 1.0))
 
     def _to_config(self) -> Tuple[str, Dict]:
+        if self.type == HyperParameter.DICT:
+            raise ValueError("Param dict of type DICT has no value")
         config = dict(value=self.value)
         return self.name, config
 
@@ -406,7 +408,14 @@ class HyperParameterSet(list):
 
     def to_config(self) -> Dict:
         """Convert a HyperParameterSet to a SweepRun config."""
-        return dict([param._to_config() for param in self])
+        config: Dict = dict()
+        for param in self:
+            if param.type == HyperParameter.DICT:
+                config[param.name] = dict()
+            else:
+                _name, _value = param._to_config()
+                config[_name] = _value
+        return config
 
     def normalize_runs_as_array(self, runs: List[SweepRun]) -> np.ndarray:
         """Normalize a list of SweepRuns to an ndarray of parameter vectors."""

--- a/src/sweeps/params.py
+++ b/src/sweeps/params.py
@@ -372,17 +372,23 @@ class HyperParameterSet(list):
         """
         hyperparameters: List[HyperParameter] = []
 
-        def _unnest(d: Dict, prefix: str = '', delimiter='.'):
+        def _unnest(d: Dict, prefix: str = "", delimiter="."):
             """Recursively search for HyperParameters in a potentially nested dictionary."""
             for key, val in sorted(d.items()):
-                assert isinstance(key, str), f"Config keys must be strings, found {key} of type {type(key)}"
+                assert isinstance(
+                    key, str
+                ), f"Config keys must be strings, found {key} of type {type(key)}"
                 if key.startswith("wb.choose."):
                     # Verify that the value is a dict containing other dicts
                     assert isinstance(val, dict), "wb.choose must be a dict"
                     choices: List[str] = []
                     for choice_key, choice_val in val.items():
-                        assert isinstance(choice_key, str), "wb.choose keys must be strings"
-                        assert isinstance(choice_val, dict), "wb.choose values must be dicts"
+                        assert isinstance(
+                            choice_key, str
+                        ), "wb.choose keys must be strings"
+                        assert isinstance(
+                            choice_val, dict
+                        ), "wb.choose values must be dicts"
                         choices.append(choice_key)
                     # Create a new HyperParameter representing the choice
                     hyperparameters.append(HyperParameter(key, {"values": choices}))

--- a/src/sweeps/params.py
+++ b/src/sweeps/params.py
@@ -16,6 +16,7 @@ from ._types import ArrayLike
 
 _logger = logging.getLogger(__name__)
 
+
 def q_log_uniform_v1_ppf(x: ArrayLike, min, max, q):
     r = np.exp(stats.uniform.ppf(x, min, max - min))
     ret_val = np.round(r / q) * q
@@ -341,7 +342,9 @@ class HyperParameterSet(list):
             elif not item.type == HyperParameter.CONSTANT:
                 # constants do not form part of the search space
                 if item.name in self.search_space:
-                    raise ValueError(f"HyperParameterSet cannot contain duplicates, got {item.name}")
+                    raise ValueError(
+                        f"HyperParameterSet cannot contain duplicates, got {item.name}"
+                    )
                 self.search_space.add(item.name)
                 self.searchable_params.append(item)
                 self.param_names_to_index[item.name] = _searchable_param_index
@@ -363,7 +366,7 @@ class HyperParameterSet(list):
         hyperparameters: List[HyperParameter] = []
 
         def _recursive_search(d: Dict):
-            """ Recursively search for HyperParameters in a potentially nested dictionary. """
+            """Recursively search for HyperParameters in a potentially nested dictionary."""
             for key, value in d.items():
                 if isinstance(value, dict):
                     _recursive_search(value)

--- a/src/sweeps/params.py
+++ b/src/sweeps/params.py
@@ -414,12 +414,10 @@ class HyperParameterSet(list):
                     assert (
                         "choices" in val
                     ), "Param of type CHOICE must have 'choices' key"
-                    hyperparameters.append(_hp)
-                    for choice_name, choice in val.items():
-                        _unnest(
-                            choice,
-                            prefix=f"{prefix}{key}{delimiter}{choice_name}{delimiter}",
-                        )
+                    # Add a CATEGORICAL parameter representing the choice
+                    _choice_hp = HyperParameter(f"{prefix}{key}", {"values": [_ for _ in val.keys()]})
+                    # Unnest any hyperparameters in the choice
+                    _unnest(val["choices"], prefix=f"{prefix}{key}{delimiter}")
                 else:
                     hyperparameters.append(_hp)
 
@@ -460,6 +458,8 @@ class HyperParameterSet(list):
             if param.type != HyperParameter.DICT:
                 _name, _value = param._name_and_value()
                 config[_name] = _value
+            if param.type == HyperParameter.CHOICE:
+                # TODO value depends on the choice another parameter?
         config = deepcopy(config)
         _renest(config)
         # TODO: Because of historical reason the first level of nesting requires "value" key

--- a/src/sweeps/params.py
+++ b/src/sweeps/params.py
@@ -354,13 +354,14 @@ class HyperParameterSet(list):
         Args:
             config: The parameters section of a SweepConfig.
         """
-        hpd = cls(
-            [
-                HyperParameter(param_name, param_config)
-                for param_name, param_config in sorted(config.items())
-            ]
-        )
-        return hpd
+        hyperparameters: List[HyperParameter] = []
+        for _name, _value in sorted(config.items()):
+            if _name == "_choice":
+                pass
+            if isinstance(_value, dict):
+                pass
+            hyperparameters.append(HyperParameter(_name, _value))
+        return hyperparameters
 
     def to_config(self) -> Dict:
         """Convert a HyperParameterSet to a SweepRun config."""

--- a/src/sweeps/params.py
+++ b/src/sweeps/params.py
@@ -379,23 +379,25 @@ class HyperParameterSet(list):
             for key, val in sorted(d.items()):
                 assert isinstance(
                     key, str
-                ), f"Config keys must be strings, found {key} of type {type(key)}"
+                ), f"Sweep config keys must be strings, found {key} of type {type(key)}"
+                assert isinstance(
+                    val, dict
+                ), f"Sweep config values must be dicts, found {val} of type {type(val)}"
+                choices.append(choice_key)
                 if key.startswith("wb.choose."):
-                    # Verify that the value is a dict containing other dicts
-                    assert isinstance(val, dict), "wb.choose must be a dict"
                     choices: List[str] = []
                     for choice_key, choice_val in val.items():
                         assert isinstance(
                             choice_key, str
-                        ), "wb.choose keys must be strings"
+                        ), f"wb.choose keys must be strings, found {choice_key} of type {type(choice_key)}"
                         assert isinstance(
                             choice_val, dict
-                        ), "wb.choose values must be dicts"
+                        ), f"wb.choose values must be dicts, found {choice_val} of type {type(choice_val)}"
                         choices.append(choice_key)
                     # Create a new HyperParameter representing the choice
                     hyperparameters.append(HyperParameter(key, {"values": choices}))
                     for _, choice_val in val.items():
-                        _unnest(choice_val, prefix=f"{key}.")
+                        _unnest(choice_val, prefix=f"{prefix}{key}{delimiter}")
                 elif isinstance(val, dict):
                     _hp = HyperParameter(key, val)
                     if _hp.type == HyperParameter.DICT:

--- a/src/sweeps/params.py
+++ b/src/sweeps/params.py
@@ -364,21 +364,24 @@ class HyperParameterSet(list):
             config: The parameters section of a SweepConfig.
         """
         hyperparameters: List[HyperParameter] = []
+        
 
-        def _recursive_search(d: Dict):
+        def _unnest(d: Dict, nest_map: Dict):
             """Recursively search for HyperParameters in a potentially nested dictionary."""
-            for key, value in d.items():
-                if isinstance(value, dict):
-                    _recursive_search(value)
+            for key, val in sorted(d.items()):
+                if "wbchoice" in key:
+                    pass
+                if isinstance(val, dict):
+                    nest_map[key] = dict()
+                    _unnest(val, )
+                elif key in nest_map:
+                    raise ValueError(f"Found conflict in nested HyperParameter names: {key}")
                 else:
-                    hyperparameters.append(HyperParameter(key, value))
+                    hyperparameters.append(HyperParameter(key, val))
 
-        for _name, _value in sorted(config.items()):
-            if _name == "_choice":
-                pass
-            if isinstance(_value, dict):
-                pass
-            hyperparameters.append(HyperParameter(_name, _value))
+        # Store nest map for later un-nesting
+        nest_map: Dict[str, Dict] = dict()
+        _unnest(config, nest_map)
         return cls(hyperparameters)
 
     def to_config(self) -> Dict:

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -112,6 +112,10 @@ def test_hyperparameterset_from_config():
     with pytest.raises(ValueError):
         _ = HyperParameterSet.from_config(run_config)
 
+    # Naming conflict for wb.choose
+
+    # All params in wb.choose must be param_dicts
+
 
 def test_hyperparameterset_to_config():
 

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -3,7 +3,11 @@ import pytest
 import numpy as np
 
 from sweeps import SweepRun, RunState
-from sweeps.params import HyperParameter, HyperParameterSet
+from sweeps.params import (
+    HyperParameter,
+    HyperParameterSet,
+    validate_hyperparam_search_space_in_runs,
+)
 
 
 def test_hyperparameterset_initialize():
@@ -91,12 +95,11 @@ def test_hyperparameterset_normalize_runs():
     normalized_runs = valid_set.normalize_runs_as_array([r1, r2])
     assert normalized_runs.shape == (2, 1)
 
+
 def test_hyperparameterset_from_config():
 
     # simple case of hyperparameters from config
-    run_config = {
-
-    }
+    run_config = {}
     hps = HyperParameterSet.from_config(run_config)
     # sorting of config items ensures order of hyperparameters
     assert hps[0] == HyperParameter("a.a", {"value": 1})
@@ -104,11 +107,8 @@ def test_hyperparameterset_from_config():
     assert hps[2] == HyperParameter("a.a", {"value": 1})
     assert hps[3] == HyperParameter("a.a", {"value": 1})
 
-
     # Error case
-    run_config = {
-
-    }
+    run_config = {}
     with pytest.raises(ValueError):
         _ = HyperParameterSet.from_config(run_config)
 
@@ -116,25 +116,43 @@ def test_hyperparameterset_from_config():
 def test_hyperparameterset_to_config():
 
     # simple case of hyperparameters to config
-    hps = HyperParameterSet([
-        HyperParameter("a.a", {"value": 1}),
-        HyperParameter("a.a", {"value": 1}),
-        HyperParameter("a.a", {"value": 1}),
-        HyperParameter("a.a", {"value": 1}),
-    ])
-    desired_run_config = {
-
-    }
+    hps = HyperParameterSet(
+        [
+            HyperParameter("a.a", {"value": 1}),
+            HyperParameter("a.a", {"value": 1}),
+            HyperParameter("a.a", {"value": 1}),
+            HyperParameter("a.a", {"value": 1}),
+        ]
+    )
+    desired_run_config = {}
     run_config = hps.to_config()
     assert desired_run_config == run_config
 
-
     # Error case
-    hps = HyperParameterSet([
-        HyperParameter("a.a", {"value": 1}),
-        HyperParameter("a.a", {"value": 1}),
-        HyperParameter("a.a", {"value": 1}),
-        HyperParameter("a.a", {"value": 1}),
-    ])
+    hps = HyperParameterSet(
+        [
+            HyperParameter("a.a", {"value": 1}),
+            HyperParameter("a.a", {"value": 1}),
+            HyperParameter("a.a", {"value": 1}),
+            HyperParameter("a.a", {"value": 1}),
+        ]
+    )
     with pytest.raises(ValueError):
         _ = hps.to_config()
+
+
+def test_validate_hyperparam_search_space_in_runs():
+
+    hps = HyperParameterSet(
+        [
+            HyperParameter("a.a", {"value": 1}),
+            HyperParameter("a.a", {"value": 1}),
+            HyperParameter("a.a", {"value": 1}),
+            HyperParameter("a.a", {"value": 1}),
+        ]
+    )
+    run_config = {}
+    # Only throws hard error if throw_error flag is specified
+    validate_hyperparam_search_space_in_runs(hps, run_config)
+    with pytest.raises(ValueError):
+        validate_hyperparam_search_space_in_runs(hps, run_config, throw_error=True)

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -158,3 +158,9 @@ def test_make_run_config_from_params_custom_delimiters(delimiter):
     )
     with pytest.raises(ValueError):
         make_run_config_from_params(params)
+
+def test_param_dict():
+    pass
+
+def test_param_choice():
+    pass

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -91,76 +91,50 @@ def test_hyperparameterset_normalize_runs():
     normalized_runs = valid_set.normalize_runs_as_array([r1, r2])
     assert normalized_runs.shape == (2, 1)
 
-def test_make_run_config_from_params():
+def test_hyperparameterset_from_config():
 
-    # Nested values by default use '.' as delimiter
-    runconf = make_run_config_from_params(
-        HyperParameterSet(
-            [
-                HyperParameter("a.a", {"value": 1}),
-                HyperParameter("a.b", {"value": 2, "nested": True}),
-                HyperParameter("a.c", {"value": 3, "nested": True}),
-                HyperParameter("a.d.e", {"value": 4, "nested": True}),
-            ]
-        )
-    )
-    assert runconf == {
-        "a.a": {"value": 1},
-        "a.b": {"value": 2},
-        "a.c": {"value": 3},
-        "a.d.e": {"value": 4},
-        "a": {"value": {"b": 2, "c": 3, "d": {"e": 4}}},
+    # simple case of hyperparameters from config
+    run_config = {
+
     }
-
-    # Nested values can't overwrite existing non-nested keys
-    params = HyperParameterSet(
-        [
-            HyperParameter("a", {"value": 1}),
-            HyperParameter("a.c", {"value": 2, "nested": True}),
-        ]
-    )
-    with pytest.raises(ValueError):
-        make_run_config_from_params(params)
+    hps = HyperParameterSet.from_config(run_config)
+    # sorting of config items ensures order of hyperparameters
+    assert hps[0] == HyperParameter("a.a", {"value": 1})
+    assert hps[1] == HyperParameter("a.a", {"value": 1})
+    assert hps[2] == HyperParameter("a.a", {"value": 1})
+    assert hps[3] == HyperParameter("a.a", {"value": 1})
 
 
-@pytest.mark.parametrize("delimiter", [".", "_", "foo"])
-def test_make_run_config_from_params_custom_delimiters(delimiter):
+    # Error case
+    run_config = {
 
-    runconf = make_run_config_from_params(
-        HyperParameterSet(
-            [
-                HyperParameter(
-                    f"a{delimiter}b",
-                    {"value": 1, "nested": True, "nest_delimiter": delimiter},
-                ),
-                HyperParameter(
-                    f"a{delimiter}c",
-                    {"value": 2, "nested": True, "nest_delimiter": delimiter},
-                ),
-            ]
-        )
-    )
-    assert runconf == {
-        f"a{delimiter}b": {"value": 1},
-        f"a{delimiter}c": {"value": 2},
-        "a": {"value": {"b": 1, "c": 2}},
     }
-
-    # Throw error if delimiters are different
-    params = HyperParameterSet(
-        [
-            HyperParameter(
-                f"a{delimiter}b",
-                {"value": 1, "nested": True, "nest_delimiter": delimiter},
-            ),
-            HyperParameter("a-c", {"value": 2, "nested": True, "nest_delimiter": "-"}),
-        ]
-    )
     with pytest.raises(ValueError):
-        make_run_config_from_params(params)
+        _ = HyperParameterSet.from_config(run_config)
 
-def test_param_dict():
-    pass
 
-def test_param_choice():
-    pass
+def test_hyperparameterset_to_config():
+
+    # simple case of hyperparameters to config
+    hps = HyperParameterSet([
+        HyperParameter("a.a", {"value": 1}),
+        HyperParameter("a.a", {"value": 1}),
+        HyperParameter("a.a", {"value": 1}),
+        HyperParameter("a.a", {"value": 1}),
+    ])
+    desired_run_config = {
+
+    }
+    run_config = hps.to_config()
+    assert desired_run_config == run_config
+
+
+    # Error case
+    hps = HyperParameterSet([
+        HyperParameter("a.a", {"value": 1}),
+        HyperParameter("a.a", {"value": 1}),
+        HyperParameter("a.a", {"value": 1}),
+        HyperParameter("a.a", {"value": 1}),
+    ])
+    with pytest.raises(ValueError):
+        _ = hps.to_config()

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,3 +1,4 @@
+from ssl import DER_cert_to_PEM_cert
 import pytest
 from copy import deepcopy
 from jsonschema import ValidationError
@@ -168,9 +169,7 @@ def test_param_dict(search_type):
                 "parameters": {
                     "b": {"value": 1},
                     "c": {
-                        "parameters": {
-                            "d": {"value": 2}
-                        },
+                        "parameters": {"d": {"value": 2}},
                     },
                 },
             },
@@ -178,10 +177,9 @@ def test_param_dict(search_type):
     }
     desired_run_config = {
         "a": {"value": {"b": 1, "c": {"d": 2}}},
-        "a.b": {"value": 1},
-        "a.c.d": {"value": 2},
     }
     run = next_run(sweep_config, [SweepRun(config=sweep_config)])
+    print(run.config)
     assert run.config == desired_run_config
 
     # naming conflict is ok as long as different nest levels
@@ -190,8 +188,12 @@ def test_param_dict(search_type):
         "metric": {"name": "loss", "goal": "minimize"},
         "parameters": {
             "a": {
-                "b": {"value": 1},
-                "c": {"d": {"value": 2}},
+                "parameters": {
+                    "b": {"value": 1},
+                    "c": {
+                        "parameters": {"d": {"value": 2}},
+                    },
+                },
             },
             "b": {"value": 2},
         },

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -155,6 +155,7 @@ def test_invalid_run_parameter():
     with pytest.raises(ValueError):
         next_run(config, runs, validate=False)
 
+
 @pytest.mark.parametrize("search_type", ["bayes", "grid", "random"])
 def test_param_dict(search_type):
     # param dict inside param dict
@@ -162,14 +163,14 @@ def test_param_dict(search_type):
         "method": search_type,
         "metric": {"name": "loss", "goal": "minimize"},
         "parameters": {
-            "a" : {
-                "b" : {"value": 1},
-                "c" : {"d" : {"value" : 2}},
+            "a": {
+                "b": {"value": 1},
+                "c": {"d": {"value": 2}},
             },
-        }
+        },
     }
     desired_run_config = {
-        "a" : {"value" : {"b" : 1, "c" : {"d" : 2}}},
+        "a": {"value": {"b": 1, "c": {"d": 2}}},
     }
     run = next_run(sweep_config, [SweepRun(config=sweep_config)])
     assert run.config == desired_run_config
@@ -179,19 +180,20 @@ def test_param_dict(search_type):
         "method": search_type,
         "metric": {"name": "loss", "goal": "minimize"},
         "parameters": {
-            "a" : {
-                "b" : {"value": 1},
-                "c" : {"d" : {"value" : 2}},
+            "a": {
+                "b": {"value": 1},
+                "c": {"d": {"value": 2}},
             },
-            "b" : {"value": 2},
-        }
+            "b": {"value": 2},
+        },
     }
     desired_run_config = {
-        "a" : {"value" : {"b" : 1, "c" : {"d" : 2}}},
-        "b" : {"value": 2},
+        "a": {"value": {"b": 1, "c": {"d": 2}}},
+        "b": {"value": 2},
     }
     run = next_run(sweep_config, [SweepRun(config=sweep_config)])
     assert run.config == desired_run_config
+
 
 @pytest.mark.parametrize("search_type", ["bayes", "grid", "random"])
 def test_choice_param(search_type):
@@ -200,18 +202,18 @@ def test_choice_param(search_type):
         "method": search_type,
         "metric": {"name": "loss", "goal": "minimize"},
         "parameters": {
-            "_choice" : {
-                "case_1" : {
-                    "a" : {"value": 1},
+            "_choice": {
+                "case_1": {
+                    "a": {"value": 1},
                 },
-                "case_2" : {
-                    "a" : {"value": 2},
-                }
+                "case_2": {
+                    "a": {"value": 2},
+                },
             },
-        }
+        },
     }
-    run_config_1 = {"a" : {"value": 1}}
-    run_config_2 = {"a" : {"value": 2}}
+    run_config_1 = {"a": {"value": 1}}
+    run_config_2 = {"a": {"value": 2}}
     run = next_run(sweep_config, [SweepRun(run_config_1)])
     assert run.config == run_config_2
 
@@ -220,20 +222,20 @@ def test_choice_param(search_type):
         "method": search_type,
         "metric": {"name": "loss", "goal": "minimize"},
         "parameters": {
-            "_choice" : {
-                "case_1" : {
-                    "a" : {"value": 1},
-                    "b" : {"value": 1},
+            "_choice": {
+                "case_1": {
+                    "a": {"value": 1},
+                    "b": {"value": 1},
                 },
-                "case_2" : {
-                    "a" : {"value": 2},
-                    "b" : {"value": 2},
-                }
+                "case_2": {
+                    "a": {"value": 2},
+                    "b": {"value": 2},
+                },
             },
-        }
+        },
     }
-    run_config_1 = {"a" : {"value": 1}, "b" : {"value": 1}}
-    run_config_2 = {"a" : {"value": 2}, "b" : {"value": 2}}
+    run_config_1 = {"a": {"value": 1}, "b": {"value": 1}}
+    run_config_2 = {"a": {"value": 2}, "b": {"value": 2}}
     run = next_run(sweep_config, [SweepRun(run_config_1)])
     assert run.config == run_config_2
 
@@ -242,25 +244,28 @@ def test_choice_param(search_type):
         "method": search_type,
         "metric": {"name": "loss", "goal": "minimize"},
         "parameters": {
-            "_choice" : {
-                "case_1" : {
-                    "a" : {"value": 1},
+            "_choice": {
+                "case_1": {
+                    "a": {"value": 1},
                 },
-                "case_2" : {
-                    "b" : {"value": 1},
-                    "c" : {"value": 1},
-                }
+                "case_2": {
+                    "b": {"value": 1},
+                    "c": {"value": 1},
+                },
             },
-        }
+        },
     }
-    run_config_1 = {"a" : {"value": 1}}
-    run_config_2 = {"b" : {"value": 1}}
-    if search_type in ['grid', 'random']:
+    run_config_1 = {"a": {"value": 1}}
+    run_config_2 = {"b": {"value": 1}}
+    if search_type in ["grid", "random"]:
         run = next_run(sweep_config, [SweepRun(run_config_1)])
         assert run.config == run_config_2
-    else: # bayes search
+    else:  # bayes search
         with pytest.raises(ValueError):
-            run = next_run(sweep_config, [SweepRun(run_config_1), SweepRun(run_config_2)])
+            run = next_run(
+                sweep_config, [SweepRun(run_config_1), SweepRun(run_config_2)]
+            )
+
 
 @pytest.mark.parametrize("search_type", ["bayes", "grid", "random"])
 def test_choice_and_param_dict_interactions(search_type):
@@ -269,20 +274,20 @@ def test_choice_and_param_dict_interactions(search_type):
         "method": search_type,
         "metric": {"name": "loss", "goal": "minimize"},
         "parameters": {
-            "a" : {
-                "_choice" : {
-                    "case_1" : {
-                        "b" : {"value": 1},
+            "a": {
+                "_choice": {
+                    "case_1": {
+                        "b": {"value": 1},
                     },
-                    "case_2" : {
-                        "b" : {"value": 2},
-                    }
+                    "case_2": {
+                        "b": {"value": 2},
+                    },
                 }
             }
-        }
+        },
     }
-    run_config_1 = {"a" : {"value": {"b" : {"value": 1}}}}
-    run_config_2 = {"a" : {"value": {"b" : {"value": 2}}}}
+    run_config_1 = {"a": {"value": {"b": {"value": 1}}}}
+    run_config_2 = {"a": {"value": {"b": {"value": 2}}}}
     run = next_run(sweep_config, [SweepRun(run_config_1)])
     assert run.config == run_config_2
 
@@ -291,20 +296,20 @@ def test_choice_and_param_dict_interactions(search_type):
         "method": search_type,
         "metric": {"name": "loss", "goal": "minimize"},
         "parameters": {
-            "a" : {
-                "_choice" : {
-                    "case_1" : {
-                        "b" : {"value": 1},
+            "a": {
+                "_choice": {
+                    "case_1": {
+                        "b": {"value": 1},
                     },
-                    "case_2" : {
-                        "c" : {"value": 1},
-                    }
+                    "case_2": {
+                        "c": {"value": 1},
+                    },
                 }
             }
-        }
+        },
     }
-    run_config_1 = {"a" : {"value": {"b" : {"value": 1}}}}
-    run_config_2 = {"a" : {"value": {"c" : {"value": 1}}}}
+    run_config_1 = {"a": {"value": {"b": {"value": 1}}}}
+    run_config_2 = {"a": {"value": {"c": {"value": 1}}}}
     run = next_run(sweep_config, [SweepRun(run_config_1)])
     assert run.config == run_config_2
 
@@ -313,28 +318,28 @@ def test_choice_and_param_dict_interactions(search_type):
         "method": search_type,
         "metric": {"name": "loss", "goal": "minimize"},
         "parameters": {
-            "a" : {
-                "_choice" : {
-                    "case_1" : {
-                        "_choice" : {
-                            "case_1" : {
-                                "b" : {"value": 1},
+            "a": {
+                "_choice": {
+                    "case_1": {
+                        "_choice": {
+                            "case_1": {
+                                "b": {"value": 1},
                             },
-                            "case_2" : {
-                                "b" : {"value": 2},
-                            }
+                            "case_2": {
+                                "b": {"value": 2},
+                            },
                         }
                     },
-                    "case_2" : {
-                        "d" : {"value": 1},
-                    }
+                    "case_2": {
+                        "d": {"value": 1},
+                    },
                 }
             }
-        }
+        },
     }
-    run_config_1 = {"a" : {"value": {"b" : 1}}}
-    run_config_2 = {"a" : {"value": {"b" : 2}}}
-    run_config_3 = {"a" : {"value": {"d" : 1}}}
+    run_config_1 = {"a": {"value": {"b": 1}}}
+    run_config_2 = {"a": {"value": {"b": 2}}}
+    run_config_3 = {"a": {"value": {"d": 1}}}
     run = next_run(sweep_config, [SweepRun(run_config_1, run_config_3)])
     assert run.config == run_config_2
     run = next_run(sweep_config, [SweepRun(run_config_1, run_config_2)])
@@ -347,28 +352,28 @@ def test_choice_and_param_dict_interactions(search_type):
         "method": search_type,
         "metric": {"name": "loss", "goal": "minimize"},
         "parameters": {
-            "_choice" : {
-                "case_1" : {
-                    "a" :{
-                        "_choice" : {
-                            "case_1" : {
-                                "b" : {"value": 1},
+            "_choice": {
+                "case_1": {
+                    "a": {
+                        "_choice": {
+                            "case_1": {
+                                "b": {"value": 1},
                             },
-                            "case_2" : {
-                                "c" : {"value": 1},
-                            }
+                            "case_2": {
+                                "c": {"value": 1},
+                            },
                         }
                     }
                 },
-                "case_2" : {
-                    "d" : {"value": 1},
-                }
+                "case_2": {
+                    "d": {"value": 1},
+                },
             }
-        }
+        },
     }
-    run_config_1 = {"a" : {"value": {"b" : 1}}}
-    run_config_2 = {"a" : {"value": {"c" : 2}}}
-    run_config_3 = {"d" : {"value": 1}}
+    run_config_1 = {"a": {"value": {"b": 1}}}
+    run_config_2 = {"a": {"value": {"c": 2}}}
+    run_config_3 = {"d": {"value": 1}}
     run = next_run(sweep_config, [SweepRun(run_config_1, run_config_3)])
     assert run.config == run_config_2
     run = next_run(sweep_config, [SweepRun(run_config_1, run_config_2)])
@@ -376,9 +381,11 @@ def test_choice_and_param_dict_interactions(search_type):
     run = next_run(sweep_config, [SweepRun(run_config_2, run_config_3)])
     assert run.config == run_config_1
 
+
 @pytest.mark.parametrize("search_type", ["bayes", "grid", "random"])
 def test_nested_conditional_run_parameter(search_type):
     pass
+
 
 def test_invalid_minmax_with_no_sweepconfig_validation():
     config = {"method": "random", "parameters": {"a": {"max": 0, "min": 1}}}

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -189,7 +189,37 @@ def test_nested_run_parameter(search_type):
 
 @pytest.mark.parametrize("search_type", ["bayes", "grid", "random"])
 def test_conditional_run_parameter(search_type):
-    pass
+    sweep_config = {
+        "method": search_type,
+        "metric": {"name": "loss", "goal": "minimize"},
+        "parameters": {
+            "batch_size": {"values": [32, 64]},
+            "model_arch": {
+                "choose_from" : {
+                    "MHA" : {
+                        "embed_size": {"values": [32, 128]},
+                        "num_heads": {"values": [1, 16]},
+                    },
+                    "fcn" : {
+                        "num_layers": {"value": False},
+                        "use_dropout": {"value": True},
+                    }
+                }
+            }
+        }
+    }
+
+    # param-dict inside a param-dict
+    sweep_config = {
+        "method": search_type,
+        "metric": {"name": "loss", "goal": "minimize"},
+        "parameters": {
+            "a" : {
+                "b" : {"values": [1, 2]},
+                "c" : {"d" : {"value" : 3}},
+            },
+        }
+    }
 
 @pytest.mark.parametrize("search_type", ["bayes", "grid", "random"])
 def test_nested_conditional_run_parameter(search_type):

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -218,34 +218,36 @@ def test_param_choice(search_type):
         "parameters": {
             "foo": {
                 "choices": {
-                    "case_1": {
-                        "a": {"value": 1},
-                    },
-                    "case_2": {
-                        "a": {"value": 2},
-                    },
+                    "a": {"value": 1},
+                    "b": {"value": 2},
                 },
             },
         },
     }
-    run_config_1 = {"a": {"value": 1}, "wb.choose.foo": "case_1"}
-    run_config_2 = {"a": {"value": 2}, "wb.choose.foo": "case_2"}
+    run_config_1 = {"a": {"value": 1}, "foo": {"value" : "a"}}
+    run_config_2 = {"b": {"value": 2}, "foo": {"value" : "b"}}
     run = next_run(sweep_config, [SweepRun(config=run_config_1)])
-    assert run.config == run_config_2
+    assert run.config in [run_config_1, run_config_2]
 
     # choice param with multiple params inside
     sweep_config = {
         "method": search_type,
         "metric": {"name": "loss", "goal": "minimize"},
         "parameters": {
-            "wb.choose.foo": {
-                "case_1": {
-                    "a": {"value": 1},
-                    "b": {"value": 1},
-                },
-                "case_2": {
-                    "a": {"value": 2},
-                    "b": {"value": 2},
+            "foo": {
+                "choices" : {
+                    "case_1": {
+                        "parameters" : {
+                            "a": {"value": 1},
+                            "b": {"value": 1},
+                        }
+                    },
+                    "case_2": {
+                        "parameters" : {
+                            "a": {"value": 2},
+                            "b": {"value": 2},
+                        }
+                    },
                 },
             },
         },
@@ -253,7 +255,7 @@ def test_param_choice(search_type):
     run_config_1 = {"a": {"value": 1}, "b": {"value": 1}, "wb.choose.foo": "case_1"}
     run_config_2 = {"a": {"value": 2}, "b": {"value": 2}, "wb.choose.foo": "case_2"}
     run = next_run(sweep_config, [SweepRun(config=run_config_1)])
-    assert run.config == run_config_2
+    assert run.config in [run_config_1, run_config_2]
 
     # Choice param resulting in different search space
     sweep_config = {

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -263,7 +263,7 @@ def test_choice_param(search_type):
             run = next_run(sweep_config, [SweepRun(run_config_1), SweepRun(run_config_2)])
 
 @pytest.mark.parametrize("search_type", ["bayes", "grid", "random"])
-def test_choice_and_param_dict_combos(search_type):
+def test_choice_and_param_dict_interactions(search_type):
     # Choice param inside a nested param
     sweep_config = {
         "method": search_type,
@@ -308,7 +308,7 @@ def test_choice_and_param_dict_combos(search_type):
     run = next_run(sweep_config, [SweepRun(run_config_1)])
     assert run.config == run_config_2
 
-    # Choice param inside a nested param inside a choice param
+    # Choice param inside a choice param inside a nested param
     sweep_config = {
         "method": search_type,
         "metric": {"name": "loss", "goal": "minimize"},
@@ -335,6 +335,40 @@ def test_choice_and_param_dict_combos(search_type):
     run_config_1 = {"a" : {"value": {"b" : 1}}}
     run_config_2 = {"a" : {"value": {"b" : 2}}}
     run_config_3 = {"a" : {"value": {"d" : 1}}}
+    run = next_run(sweep_config, [SweepRun(run_config_1, run_config_3)])
+    assert run.config == run_config_2
+    run = next_run(sweep_config, [SweepRun(run_config_1, run_config_2)])
+    assert run.config == run_config_3
+    run = next_run(sweep_config, [SweepRun(run_config_2, run_config_3)])
+    assert run.config == run_config_1
+
+    # choice param inside nested param inside a choice param
+    sweep_config = {
+        "method": search_type,
+        "metric": {"name": "loss", "goal": "minimize"},
+        "parameters": {
+            "_choice" : {
+                "case_1" : {
+                    "a" :{
+                        "_choice" : {
+                            "case_1" : {
+                                "b" : {"value": 1},
+                            },
+                            "case_2" : {
+                                "c" : {"value": 1},
+                            }
+                        }
+                    }
+                },
+                "case_2" : {
+                    "d" : {"value": 1},
+                }
+            }
+        }
+    }
+    run_config_1 = {"a" : {"value": {"b" : 1}}}
+    run_config_2 = {"a" : {"value": {"c" : 2}}}
+    run_config_3 = {"d" : {"value": 1}}
     run = next_run(sweep_config, [SweepRun(run_config_1, run_config_3)])
     assert run.config == run_config_2
     run = next_run(sweep_config, [SweepRun(run_config_1, run_config_2)])

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -156,7 +156,8 @@ def test_invalid_run_parameter():
         next_run(config, runs, validate=False)
 
 
-@pytest.mark.parametrize("search_type", ["bayes", "grid", "random"])
+# @pytest.mark.parametrize("search_type", ["bayes", "grid", "random"])
+@pytest.mark.parametrize("search_type", ["random"])
 def test_param_dict(search_type):
     # param dict inside param dict
     sweep_config = {
@@ -164,15 +165,21 @@ def test_param_dict(search_type):
         "metric": {"name": "loss", "goal": "minimize"},
         "parameters": {
             "a": {
-                "b": {"value": 1},
-                "c": {"d": {"value": 2}},
+                "parameters": {
+                    "b": {"value": 1},
+                    "c": {
+                        "parameters": {
+                            "d": {"value": 2}
+                        },
+                    },
+                },
             },
         },
     }
     desired_run_config = {
         "a": {"value": {"b": 1, "c": {"d": 2}}},
-        "a.b" : {"value": 1},
-        "a.c.d" : {"value": 2},
+        "a.b": {"value": 1},
+        "a.c.d": {"value": 2},
     }
     run = next_run(sweep_config, [SweepRun(config=sweep_config)])
     assert run.config == desired_run_config
@@ -205,7 +212,7 @@ def test_choice_param(search_type):
         "metric": {"name": "loss", "goal": "minimize"},
         "parameters": {
             "foo": {
-                "choices" :{
+                "choices": {
                     "case_1": {
                         "a": {"values": [1, 2, 3]},
                     },

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -202,7 +202,7 @@ def test_choice_param(search_type):
         "method": search_type,
         "metric": {"name": "loss", "goal": "minimize"},
         "parameters": {
-            "_choice": {
+            "wb.choose.foo": {
                 "case_1": {
                     "a": {"value": 1},
                 },
@@ -212,8 +212,8 @@ def test_choice_param(search_type):
             },
         },
     }
-    run_config_1 = {"a": {"value": 1}}
-    run_config_2 = {"a": {"value": 2}}
+    run_config_1 = {"a": {"value": 1}, "wb.choose.foo": "case_1"}
+    run_config_2 = {"a": {"value": 2}, "wb.choose.foo": "case_2"}
     run = next_run(sweep_config, [SweepRun(run_config_1)])
     assert run.config == run_config_2
 
@@ -222,7 +222,7 @@ def test_choice_param(search_type):
         "method": search_type,
         "metric": {"name": "loss", "goal": "minimize"},
         "parameters": {
-            "_choice": {
+            "wb.choose.foo": {
                 "case_1": {
                     "a": {"value": 1},
                     "b": {"value": 1},
@@ -234,8 +234,8 @@ def test_choice_param(search_type):
             },
         },
     }
-    run_config_1 = {"a": {"value": 1}, "b": {"value": 1}}
-    run_config_2 = {"a": {"value": 2}, "b": {"value": 2}}
+    run_config_1 = {"a": {"value": 1}, "b": {"value": 1}, "wb.choose.foo": "case_1"}
+    run_config_2 = {"a": {"value": 2}, "b": {"value": 2}, "wb.choose.foo": "case_2"}
     run = next_run(sweep_config, [SweepRun(run_config_1)])
     assert run.config == run_config_2
 
@@ -244,7 +244,7 @@ def test_choice_param(search_type):
         "method": search_type,
         "metric": {"name": "loss", "goal": "minimize"},
         "parameters": {
-            "_choice": {
+            "wb.choose.foo": {
                 "case_1": {
                     "a": {"value": 1},
                 },
@@ -255,8 +255,8 @@ def test_choice_param(search_type):
             },
         },
     }
-    run_config_1 = {"a": {"value": 1}}
-    run_config_2 = {"b": {"value": 1}}
+    run_config_1 = {"a": {"value": 1}, "wb.choose.foo": "case_1"}
+    run_config_2 = {"b": {"value": 1}, "c": {"value": 1}, "wb.choose.foo": "case_2"}
     if search_type in ["grid", "random"]:
         run = next_run(sweep_config, [SweepRun(run_config_1)])
         assert run.config == run_config_2
@@ -275,7 +275,7 @@ def test_choice_and_param_dict_interactions(search_type):
         "metric": {"name": "loss", "goal": "minimize"},
         "parameters": {
             "a": {
-                "_choice": {
+                "wb.choose.foo": {
                     "case_1": {
                         "b": {"value": 1},
                     },
@@ -286,8 +286,8 @@ def test_choice_and_param_dict_interactions(search_type):
             }
         },
     }
-    run_config_1 = {"a": {"value": {"b": {"value": 1}}}}
-    run_config_2 = {"a": {"value": {"b": {"value": 2}}}}
+    run_config_1 = {"a": {"value": {"b": 1, "wb.choose.foo": "case_1"}}}
+    run_config_2 = {"a": {"value": {"b": 2, "wb.choose.foo": "case_2"}}}
     run = next_run(sweep_config, [SweepRun(run_config_1)])
     assert run.config == run_config_2
 
@@ -297,7 +297,7 @@ def test_choice_and_param_dict_interactions(search_type):
         "metric": {"name": "loss", "goal": "minimize"},
         "parameters": {
             "a": {
-                "_choice": {
+                "wb.choose.foo": {
                     "case_1": {
                         "b": {"value": 1},
                     },
@@ -308,8 +308,8 @@ def test_choice_and_param_dict_interactions(search_type):
             }
         },
     }
-    run_config_1 = {"a": {"value": {"b": {"value": 1}}}}
-    run_config_2 = {"a": {"value": {"c": {"value": 1}}}}
+    run_config_1 = {"a": {"value": {"b": 1, "wb.choose.foo": "case_1"}}}
+    run_config_2 = {"a": {"value": {"c": 1, "wb.choose.foo": "case_2"}}}
     run = next_run(sweep_config, [SweepRun(run_config_1)])
     assert run.config == run_config_2
 
@@ -319,9 +319,9 @@ def test_choice_and_param_dict_interactions(search_type):
         "metric": {"name": "loss", "goal": "minimize"},
         "parameters": {
             "a": {
-                "_choice": {
+                "wb.choose.foo": {
                     "case_1": {
-                        "_choice": {
+                        "wb.choose.bar": {
                             "case_1": {
                                 "b": {"value": 1},
                             },
@@ -337,9 +337,13 @@ def test_choice_and_param_dict_interactions(search_type):
             }
         },
     }
-    run_config_1 = {"a": {"value": {"b": 1}}}
-    run_config_2 = {"a": {"value": {"b": 2}}}
-    run_config_3 = {"a": {"value": {"d": 1}}}
+    run_config_1 = {
+        "a": {"value": {"b": 1, "wb.choose.foo": "case_1", "wb.choose.bar": "case_1"}}
+    }
+    run_config_2 = {
+        "a": {"value": {"b": 2, "wb.choose.foo": "case_1", "wb.choose.bar": "case_2"}}
+    }
+    run_config_3 = {"a": {"value": {"d": 1, "wb.choose.foo": "case_2"}}}
     run = next_run(sweep_config, [SweepRun(run_config_1, run_config_3)])
     assert run.config == run_config_2
     run = next_run(sweep_config, [SweepRun(run_config_1, run_config_2)])

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -171,6 +171,8 @@ def test_param_dict(search_type):
     }
     desired_run_config = {
         "a": {"value": {"b": 1, "c": {"d": 2}}},
+        "a.b" : {"value": 1},
+        "a.c.d" : {"value": 2},
     }
     run = next_run(sweep_config, [SweepRun(config=sweep_config)])
     assert run.config == desired_run_config
@@ -202,12 +204,14 @@ def test_choice_param(search_type):
         "method": search_type,
         "metric": {"name": "loss", "goal": "minimize"},
         "parameters": {
-            "wb.choose.foo": {
-                "case_1": {
-                    "a": {"value": 1},
-                },
-                "case_2": {
-                    "a": {"value": 2},
+            "foo": {
+                "choices" :{
+                    "case_1": {
+                        "a": {"values": [1, 2, 3]},
+                    },
+                    "case_2": {
+                        "a": {"value": 2},
+                    },
                 },
             },
         },


### PR DESCRIPTION
Modifies the `jsonschema` for sweeps to allow for nested parameters, conditional parameters, and nested conditional parameters. 

### Addresses:
- [WB-1799](https://wandb.atlassian.net/browse/WB-1799)
- [WB-1917](https://wandb.atlassian.net/browse/WB-1917)

### Features
- Nested parameter functionality is added through the new parameter type `param-dict`. Parameters of this type can contain any other parameter type, including another `param-dict`. 
- Conditional parameter functionality is added through the new parameter type `param-choice`. When a run suggestion is generated, only one param of `param-choice` type will be chosen per nest level. In situations where choices result in different sets of parameters (and thus a different search space), a warning will be displayed. If the search algorithm is bayes, the warning will be an Error.
- Search space for a list of runs can now be verified with `validate_hyperparam_search_space_in_runs` optionally throw errors if consistency is required (e.g. Bayes search).

### Examples:

This is a valid sweep config:
```
    sweep_config = {
        "method": search_type,
        "metric": {"name": "loss", "goal": "minimize"},
        "parameters": {
            "a" : {
                "_choice" : {
                    "case_1" : {
                        "_choice" : {
                            "case_1" : {
                                "b" : {"value": 1},
                            },
                            "case_2" : {
                                "b" : {"value": 2},
                            }
                        }
                    },
                    "case_2" : {
                        "d" : {"value": 1},
                    }
                }
            }
        }
    }
    run_config_1 = {"a" : {"value": {"b" : 1}}}
    run_config_2 = {"a" : {"value": {"b" : 2}}}
    run_config_3 = {"a" : {"value": {"d" : 1}}}
```