### PR TITLE
Bump scikit version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy>=1.15
 scipy>=1.5.4
 PyYAML
-scikit_learn==0.24.1
+scikit_learn==0.24.2
 jsonschema>=3.2.0
 jsonref>=0.2
 pydantic>=1.8.2


### PR DESCRIPTION
Address https://security.snyk.io/vuln/SNYK-PYTHON-SCIKITLEARN-1079100 by bumping scikit-learn minor version.