### PR TITLE
added run_cap to schema.json for upcoming sweep cap PR

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v4.1.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
       - id: trailing-whitespace
       - id: check-json
   - repo: https://github.com/python/black
-    rev: 22.10.0
+    rev: 22.8.0
     hooks:
       - id: black
         pass_filenames: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,18 +1,18 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.5.0
+    rev: v4.3.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
       - id: check-json
   - repo: https://github.com/python/black
-    rev: 22.3.0
+    rev: 22.10.0
     hooks:
       - id: black
         pass_filenames: true
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.4
+    rev: 5.0.4
     hooks:
       - id: flake8
         pass_filenames: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v3.4.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer

--- a/src/sweeps/config/schema.json
+++ b/src/sweeps/config/schema.json
@@ -775,7 +775,8 @@
     },
     "run_cap": {
       "type": "number",
-      "description": "Sweep will run no more than this number of runs, across any number of agents"
+      "description": "Sweep will run no more than this number of runs, across any number of agents",
+      "exclusiveMinimum": 0
     },
     "metric": {
       "type": "object",

--- a/src/sweeps/config/schema.json
+++ b/src/sweeps/config/schema.json
@@ -773,6 +773,10 @@
       "type": "string",
       "description": "The name of the sweep, displayed in the W&B UI"
     },
+    "run_cap": {
+      "type": "number",
+      "description": "Sweep will run no more than this number of runs, across any number of agents"
+    },
     "metric": {
       "type": "object",
       "description": "Metric to optimize",

--- a/src/sweeps/config/schema.json
+++ b/src/sweeps/config/schema.json
@@ -774,7 +774,7 @@
       "description": "The name of the sweep, displayed in the W&B UI"
     },
     "run_cap": {
-      "type": "number",
+      "type": "integer",
       "description": "Sweep will run no more than this number of runs, across any number of agents",
       "exclusiveMinimum": 0
     },

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -237,3 +237,22 @@ def test_that_minmax_validation_fails_on_loguniform_values_types(parameter_type)
 
     with pytest.raises(ValueError):
         fill_parameter("a", schema["parameters"]["a"])
+
+
+@pytest.mark.parametrize(
+    "run_cap",
+    [-1, 0, 1, 300],
+)
+def test_that_run_cap_validation_works_for_min_value(run_cap):
+    schema = {
+        "method": "random",
+        "parameters": {"a": {"values": [1, 2, 3, 4]}},
+        "run_cap": run_cap,
+    }
+
+    violations = schema_violations_from_proposed_config(schema)
+
+    if run_cap <= 0:
+        assert len(violations) == 1
+    else:
+        assert len(violations) == 0

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -241,7 +241,7 @@ def test_that_minmax_validation_fails_on_loguniform_values_types(parameter_type)
 
 @pytest.mark.parametrize(
     "run_cap",
-    [-1, 0, 1, 300],
+    [-1, 0, 1, 300, -0.3, 5.1, "1"],
 )
 def test_that_run_cap_validation_works_for_min_value(run_cap):
     schema = {
@@ -252,7 +252,10 @@ def test_that_run_cap_validation_works_for_min_value(run_cap):
 
     violations = schema_violations_from_proposed_config(schema)
 
-    if run_cap <= 0:
+    if type(run_cap) != int:
+        # -0.3 has two errors
+        assert len(violations) >= 1
+    elif run_cap <= 0:
         assert len(violations) == 1
     else:
         assert len(violations) == 0


### PR DESCRIPTION
With this parameter in the configuration, sweeps can be forced to only run a certain number of runs. While this functionality already exists for vanilla sweeps on a per-agent basis, we really want a solution to that covers sweeps on launch as well as handles multiple agents. Sticking this in the schema feels like the easiest option. 