### PR TITLE
fix(sweeps): Fix nested parameters in grid search

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = -n 4 --profile --junitxml="result.xml"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,0 @@
-[pytest]
-addopts = -n 4 --profile --junitxml="result.xml"

--- a/src/sweeps/grid_search.py
+++ b/src/sweeps/grid_search.py
@@ -90,6 +90,10 @@ def grid_search_next_runs(
                 },
             )
 
+    import pdb
+
+    pdb.set_trace()
+
     # we can only deal with discrete params in a grid search
     discrete_params = HyperParameterSet(
         [p for p in params if p.type == HyperParameter.CATEGORICAL]

--- a/src/sweeps/grid_search.py
+++ b/src/sweeps/grid_search.py
@@ -115,19 +115,11 @@ def grid_search_next_runs(
     for run in runs:
         hashes: list[str] = []
         for name in param_names:
-            nested_key = name.split(HyperParameterSet.NESTING_DELIMITER)
+            nested_key: list[str] = name.split(HyperParameterSet.NESTING_DELIMITER)
+            nested_key.insert(1, "value")
 
-            correct_nested_key: list[str] = []
-
-            for i, k in enumerate(nested_key):
-                correct_nested_key.append(k)
-                if i == 0:
-                    correct_nested_key.append("value")
-
-            if util.dict_has_nested_key(run.config, correct_nested_key):
-                hashes.append(
-                    yaml_hash(util.get_nested_value(run.config, correct_nested_key))
-                )
+            if util.dict_has_nested_key(run.config, nested_key):
+                hashes.append(yaml_hash(util.get_nested_value(run.config, nested_key)))
         param_hashes_seen.add(tuple(hashes))
 
     hash_gen = (

--- a/src/sweeps/grid_search.py
+++ b/src/sweeps/grid_search.py
@@ -1,6 +1,7 @@
 import hashlib
 import itertools
 import random
+import typing
 from typing import Any, List, Optional, Union
 
 import numpy as np
@@ -111,11 +112,13 @@ def grid_search_next_runs(
     if randomize_order:
         random.shuffle(all_param_hashes)
 
-    param_hashes_seen: set[tuple[str]] = set()
+    param_hashes_seen: typing.Set[typing.Tuple] = set()
     for run in runs:
-        hashes: list[str] = []
+        hashes: typing.List[str] = []
         for name in param_names:
-            nested_key: list[str] = name.split(HyperParameterSet.NESTING_DELIMITER)
+            nested_key: typing.List[str] = name.split(
+                HyperParameterSet.NESTING_DELIMITER
+            )
             nested_key.insert(1, "value")
 
             if util.dict_has_nested_key(run.config, nested_key):

--- a/src/sweeps/util.py
+++ b/src/sweeps/util.py
@@ -1,0 +1,34 @@
+import typing
+
+
+def get_nested_value(obj: dict, key: list[str]) -> typing.Any:
+    """Get a nested value from a dictionary.
+
+    Args:
+        obj (dict): The dictionary to search.
+        key (str): The key to search for.
+
+    Returns:
+        The value corresponding to the key. Raises a KeyError if the key is not found.
+    """
+    for subkey in key:
+        obj = obj[subkey]
+    return obj
+
+
+def dict_has_nested_key(obj: dict, key: list[str]) -> bool:
+    """Check if a dictionary has a nested key.
+
+    Args:
+        obj (dict): The dictionary to search.
+        key (str): The key to search for.
+
+    Returns:
+        True if the key is found, False otherwise.
+    """
+    try:
+        get_nested_value(obj, key)
+    except KeyError:
+        return False
+    else:
+        return True

--- a/src/sweeps/util.py
+++ b/src/sweeps/util.py
@@ -1,7 +1,7 @@
 import typing
 
 
-def get_nested_value(obj: dict, key: list[str]) -> typing.Any:
+def get_nested_value(obj: dict, key: typing.List[str]) -> typing.Any:
     """Get a nested value from a dictionary.
 
     Args:
@@ -16,7 +16,7 @@ def get_nested_value(obj: dict, key: list[str]) -> typing.Any:
     return obj
 
 
-def dict_has_nested_key(obj: dict, key: list[str]) -> bool:
+def dict_has_nested_key(obj: dict, key: typing.List[str]) -> bool:
     """Check if a dictionary has a nested key.
 
     Args:

--- a/tests/test_grid_search.py
+++ b/tests/test_grid_search.py
@@ -411,9 +411,12 @@ def test_nested_grid_search_advances():
 
     config = request_body["config"]
     runs = [SweepRun(**run) for run in request_body["runs"]]
-    nargs = request_body["nArgs"]
-
 
     result = next_runs(config, runs, validate=False, n=1)
 
-    assert not all([result[0].config[pname]['value'] == runs[0].config[pname]['value'] for pname in result[0].config])
+    assert not all(
+        [
+            result[0].config[pname]["value"] == runs[0].config[pname]["value"]
+            for pname in result[0].config
+        ]
+    )

--- a/tests/test_grid_search.py
+++ b/tests/test_grid_search.py
@@ -348,3 +348,72 @@ def test_q_uniform_bounded_grid_search(randomize, vectorize):
         vectorize=vectorize,
         answers=[(v, "test") for v in np.arange(-9.211, 23.23, 2.341)],
     )
+
+
+def test_nested_grid_search_advances():
+    request_body = {
+        "config": {
+            "method": "grid",
+            "metric": {"goal": "minimize", "name": "loss"},
+            "command": ["${env}", "python3", "-m", "hellowsweep"],
+            "project": "sweep_test",
+            "parameters": {
+                "p1": {"values": ["a", "b", "c"]},
+                "p2": {
+                    "parameters": {
+                        "n1": {"values": [0.01, 0.001]},
+                        "n2": {"value": 0.9},
+                        "n3": {"values": [1, 2, 3]},
+                    }
+                },
+            },
+            "description": "hellosweep: A sample program for getting started with wandb sweeps.",
+        },
+        "nArgs": 1,
+        "requestId": "9eff8681-25cf-4b9f-9561-a8675e2100f7",
+        "runs": [
+            {
+                "name": "6s48hvhy",
+                "config": {
+                    "p1": {"desc": None, "value": "a"},
+                    "p2": {"desc": None, "value": {"n1": 0.01, "n2": 0.9, "n3": 1}},
+                    "_wandb": {
+                        "desc": None,
+                        "value": {
+                            "t": {
+                                "1": [55],
+                                "2": [55],
+                                "3": [2, 23, 37],
+                                "4": "3.10.7",
+                                "5": "0.13.6.dev1",
+                                "8": [4, 5],
+                            },
+                            "start_time": 1671759722.030263,
+                            "cli_version": "0.13.6.dev1",
+                            "is_jupyter_run": False,
+                            "python_version": "3.10.7",
+                            "is_kaggle_kernel": False,
+                        },
+                    },
+                },
+                "state": "finished",
+                "summaryMetrics": {
+                    "loss": 0.009000000000000001,
+                    "_step": 0,
+                    "label": "a",
+                    "_wandb": {"runtime": 0},
+                    "_runtime": 0.33578920364379883,
+                    "_timestamp": 1671759722.3660522,
+                },
+            },
+        ],
+    }
+
+    config = request_body["config"]
+    runs = [SweepRun(**run) for run in request_body["runs"]]
+    nargs = request_body["nArgs"]
+
+
+    result = next_runs(config, runs, validate=False, n=1)
+
+    assert not all([result[0].config[pname]['value'] == runs[0].config[pname]['value'] for pname in result[0].config])


### PR DESCRIPTION
Since the release of nested parameters, any grid search using them would simply return the first parameter in the search forever, never progressing to the second parameter. The reason for this is because grid search was not updated to search the run configs for the parameters following the new nested / recursive layout. This PR fixes this, and adds a test. 