### PR TITLE
chore(sweeps): no validation for custom method

### DIFF
--- a/src/sweeps/run.py
+++ b/src/sweeps/run.py
@@ -205,8 +205,6 @@ def next_runs(
             "Parameters section of sweep config must be a dict of at least length 1"
         )
 
-    method = sweep_config["method"]
-
     if method == "grid":
         return grid_search_next_runs(
             runs, sweep_config, validate=validate, n=n, **kwargs

--- a/src/sweeps/run.py
+++ b/src/sweeps/run.py
@@ -189,6 +189,11 @@ def next_runs(
     if "method" not in sweep_config:
         raise ValueError("Sweep config must contain method section")
 
+    method = sweep_config["method"]
+
+    if method == "custom":  # no validation
+        return [None]
+
     if "parameters" not in sweep_config:
         raise ValueError("Sweep config must contain parameters section")
 


### PR DESCRIPTION
Don't do the extra validation step for custom methods. Enables external schedulers overloading the existing "custom" method.