### PR TITLE
fix(sweeps): handle gaussian process normalization for nested params in bayes

### DIFF
--- a/src/sweeps/grid_search.py
+++ b/src/sweeps/grid_search.py
@@ -7,10 +7,10 @@ from typing import Any, List, Optional, Union
 import numpy as np
 import yaml
 
+from . import util
 from .config.cfg import SweepConfig
 from .params import HyperParameter, HyperParameterSet
 from .run import SweepRun
-from . import util
 
 
 def yaml_hash(value: Any) -> str:

--- a/src/sweeps/params.py
+++ b/src/sweeps/params.py
@@ -437,7 +437,9 @@ class HyperParameterSet(list):
             try:
                 return config[_param_name]["value"][_sub_param_name]
             except Exception:
-                raise KeyError(f"Could not find nested parameter {param_name} in config")
+                raise KeyError(
+                    f"Could not find nested parameter {param_name} in config"
+                )
         else:
             try:
                 return config[param_name]["value"]

--- a/src/sweeps/params.py
+++ b/src/sweeps/params.py
@@ -437,14 +437,15 @@ class HyperParameterSet(list):
             try:
                 return config[_param_name]["value"][_sub_param_name]
             except Exception:
-                raise KeyError(
+                logging.warning(
                     f"Could not find nested parameter {param_name} in config"
                 )
         else:
             try:
                 return config[param_name]["value"]
             except Exception:
-                raise KeyError(f"Could not find parameter {param_name} in config")
+                logging.warning(f"Could not find parameter {param_name} in config")
+        return None
 
     def normalize_runs_as_array(self, runs: List[SweepRun]) -> np.ndarray:
         """Normalize a list of SweepRuns to an ndarray of parameter vectors."""
@@ -454,7 +455,9 @@ class HyperParameterSet(list):
             row: np.ndarray = np.zeros(len(runs))  # default to 0
             for i, run in enumerate(runs):
                 _val = self._get_val_from_config(run.config, param_name)
-                if _param.type == HyperParameter.CATEGORICAL:
+                if not _val:
+                    row[i] = 0.0
+                elif _param.type == HyperParameter.CATEGORICAL:
                     row[i] = _param.value_to_idx(_val)
                 else:
                     row[i] = _val

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -71,6 +71,35 @@ def test_hyperparameterset_normalize_runs():
     normalized_runs = valid_set.normalize_runs_as_array([r1, r2])
     assert normalized_runs.shape == (2, 1)
 
+    # Prior runs w/ nested params respect params
+    _delimiter = HyperParameterSet.NESTING_DELIMITER
+    hps = HyperParameterSet(
+        [
+            HyperParameter(f"a{_delimiter}b", {"value": 1}),
+            HyperParameter(f"a{_delimiter}c{_delimiter}d", {"value": 1}),
+        ]
+    )
+    r1 = SweepRun(
+        name="b",
+        state=RunState.finished,
+        config={f"a{_delimiter}b": {"value": 1}},
+        history=[],
+    )
+    r2 = SweepRun(
+        name="b",
+        state=RunState.finished,
+        config={f"a{_delimiter}c{_delimiter}d": {"value": 1}, f"a{_delimiter}b": {"value": np.inf}},
+        history=[],
+    )
+    r3 = SweepRun(
+        name="b",
+        state=RunState.finished,
+        config={f"a{_delimiter}c{_delimiter}d": {"value": -1}},
+        history=[],
+    )
+    normalized_runs = hps.normalize_runs_as_array([r1, r2, r3])
+    assert normalized_runs.shape == (3, 1)
+
     valid_set = HyperParameterSet(
         [
             HyperParameter("v1", {"value": 1}),

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -53,6 +53,7 @@ def test_hyperparameterset_normalize_runs():
     normalized_runs = valid_set.normalize_runs_as_array([r1, r2])
     assert normalized_runs.shape == (2, 1)
 
+    # TODO(gst): fix test, or allow for this case. When can this happen?
     valid_set = HyperParameterSet(
         [
             HyperParameter("v1", {"value": 1}),

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -53,21 +53,23 @@ def test_hyperparameterset_normalize_runs():
     normalized_runs = valid_set.normalize_runs_as_array([r1, r2])
     assert normalized_runs.shape == (2, 1)
 
-    # TODO(gst): fix test, or allow for this case. When can this happen?
-    valid_set = HyperParameterSet(
-        [
-            HyperParameter("v1", {"value": 1}),
-            HyperParameter("v2", {"values": [1, 2]}),
-        ]
-    )
-    r1 = SweepRun(
-        name="b",
-        state=RunState.finished,
-        config={"v1": {"value": 1}},
-        history=[],
-    )
-    normalized_runs = valid_set.normalize_runs_as_array([r1, r2])
-    assert normalized_runs.shape == (2, 1)
+    # TODO(gst): we currently don't support conditional logic, run can never have
+    #            a subset of the sweep parameters like below
+
+    # valid_set = HyperParameterSet(
+    #     [
+    #         HyperParameter("v1", {"value": 1}),
+    #         HyperParameter("v2", {"values": [1, 2]}),
+    #     ]
+    # )
+    # r1 = SweepRun(
+    #     name="b",
+    #     state=RunState.finished,
+    #     config={"v1": {"value": 1}},
+    #     history=[],
+    # )
+    # normalized_runs = valid_set.normalize_runs_as_array([r1, r2])
+    # assert normalized_runs.shape == (2, 1)
 
     valid_set = HyperParameterSet(
         [

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -53,23 +53,23 @@ def test_hyperparameterset_normalize_runs():
     normalized_runs = valid_set.normalize_runs_as_array([r1, r2])
     assert normalized_runs.shape == (2, 1)
 
-    # TODO(gst): we currently don't support conditional logic, run can never have
-    #            a subset of the sweep parameters like below
-
-    # valid_set = HyperParameterSet(
-    #     [
-    #         HyperParameter("v1", {"value": 1}),
-    #         HyperParameter("v2", {"values": [1, 2]}),
-    #     ]
-    # )
-    # r1 = SweepRun(
-    #     name="b",
-    #     state=RunState.finished,
-    #     config={"v1": {"value": 1}},
-    #     history=[],
-    # )
-    # normalized_runs = valid_set.normalize_runs_as_array([r1, r2])
-    # assert normalized_runs.shape == (2, 1)
+    # This test includes prior runs that have more parameters than the sweep config.
+    #    we should log a warning, but allow runs to be created/optimized.
+    #    no parameter defaults to zero
+    valid_set = HyperParameterSet(
+        [
+            HyperParameter("v1", {"value": 1}),
+            HyperParameter("v2", {"values": [1, 2]}),
+        ]
+    )
+    r1 = SweepRun(
+        name="b",
+        state=RunState.finished,
+        config={"v1": {"value": 1}},
+        history=[],
+    )
+    normalized_runs = valid_set.normalize_runs_as_array([r1, r2])
+    assert normalized_runs.shape == (2, 1)
 
     valid_set = HyperParameterSet(
         [

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -88,7 +88,10 @@ def test_hyperparameterset_normalize_runs():
     r2 = SweepRun(
         name="b",
         state=RunState.finished,
-        config={f"a{_delimiter}c{_delimiter}d": {"value": 1}, f"a{_delimiter}b": {"value": np.inf}},
+        config={
+            f"a{_delimiter}c{_delimiter}d": {"value": 1},
+            f"a{_delimiter}b": {"value": np.inf},
+        },
         history=[],
     )
     r3 = SweepRun(

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -93,7 +93,6 @@ def test_hyperparameterset_normalize_runs():
     assert normalized_runs.shape == (2, 1)
 
     # Prior runs w/ nested params respect params
-    _delimiter = HyperParameterSet.NESTING_DELIMITER
     sweep_config = {
         "method": "grid",
         "metric": {"name": "loss", "goal": "minimize"},


### PR DESCRIPTION
[Jira ticket](https://wandb.atlassian.net/browse/WB-13862)

Basic test with this config:

```yaml
method: bayes
program: train.py
metric:
   name: val_acc
   goal: maximize

parameters:
   a:
      min: 0
      max: 10
   nested1:
      parameters:
          nested2:
              values: [1, 2, 3, 4]
          nested3:
              min: 0
              max: 2
```

Tests: 

- Additional test for deep nested configs

