### PR TITLE
feat: default to strict hyperband sweeps

### DIFF
--- a/src/sweeps/config/schema.json
+++ b/src/sweeps/config/schema.json
@@ -701,8 +701,8 @@
         },
         "strict": {
           "type": "boolean",
-          "description": "Use a more aggresive condition for termination, stops more runs",
-          "default": false
+          "description": "Use the stricter condition for termination outlined in the original algorithm, stops more runs",
+          "default": true
         }
       }
     }


### PR DESCRIPTION
Lets default all new hyperband sweeps to using the more aggressive stopping. Can be easily turned off. 