### PR TITLE
Grid sweeps no longer run endlessly when whole-number floats are used in sweep config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
           command: pyenv global 3.7.11
       - run:
           name: Run tests
-          command: pip install tox==3.24.0 && tox -e py37
+          command: pip install pluggy==1.4.0 tox==3.24.0 && tox -e py37
       - codecov/upload:
           file: coverage.xml
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
           command: pyenv global 3.7.11
       - run:
           name: Run tests
-          command: pip install pluggy==1.4.0 tox==3.24.0 && tox -e py37
+          command: pip install tox==3.24.0 && tox -e py37
       - codecov/upload:
           file: coverage.xml
       - store_artifacts:
@@ -36,7 +36,7 @@ jobs:
           command: pyenv global 3.8.5
       - run:
           name: Run Tests
-          command: pip install tox==3.24.0 && tox -e py38
+          command: pip install pluggy==1.4.0 tox==3.24.0 && tox -e py38
       - codecov/upload:
           file: coverage.xml
       - store_artifacts:

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -1,5 +1,5 @@
 -r requirements.dev.txt
-pytest==6.2.5
+pytest==7.4.0
 pytest-cov==2.11.1
 pytest-randomly==3.8.0
 matplotlib>=3

--- a/src/sweeps/grid_search.py
+++ b/src/sweeps/grid_search.py
@@ -19,7 +19,7 @@ def yaml_hash(value: Any) -> str:
         # Generally this isn't a problem, but when a run config value is something like "3e6" it's interpreted as a float
         # when creating the hyperparameter set from the sweep config, but becomes an int when it becomes part of the
         # run config in AgentHeartbeat (this happens in the line "configStr := string(config)" in mutation.go)
-        if float(int(value)) == value:
+        if value.is_integer():
             value = int(value)
     return hashlib.md5(
         yaml.dump(value, default_flow_style=True, sort_keys=True).encode("ascii")

--- a/src/sweeps/grid_search.py
+++ b/src/sweeps/grid_search.py
@@ -14,6 +14,13 @@ from .run import SweepRun
 
 
 def yaml_hash(value: Any) -> str:
+    if isinstance(value, float):
+        # Convert integer floats to ints, so that e.g. 3000000.0 == 3000000
+        # Generally this isn't a problem, but when a run config value is something like "3e6" it's interpreted as a float
+        # when creating the hyperparameter set from the sweep config, but becomes an int when it becomes part of the
+        # run config in AgentHeartbeat (this happens in the line "configStr := string(config)" in mutation.go)
+        if float(int(value)) == value:
+            value = int(value)
     return hashlib.md5(
         yaml.dump(value, default_flow_style=True, sort_keys=True).encode("ascii")
     ).hexdigest()

--- a/tests/test_grid_search.py
+++ b/tests/test_grid_search.py
@@ -3,6 +3,7 @@ from typing import List, Sequence, Tuple
 import numpy as np
 import pytest
 from sweeps.config import SweepConfig
+from sweeps.grid_search import yaml_hash
 from sweeps.run import RunState, SweepRun, next_run, next_runs
 
 
@@ -420,3 +421,7 @@ def test_nested_grid_search_advances():
             for pname in result[0].config
         ]
     )
+
+
+def test_yaml_hash_float():
+    assert yaml_hash(3000000.0) == yaml_hash(3000000)


### PR DESCRIPTION
Jira ticket: https://wandb.atlassian.net/browse/WB-18336

# Description

See my lengthy code comment below - Values like `3000000.0` is a float but gets mangled into an int, and since `3000000.0` has a different hash from `3000000`, we think that we haven't run a particular run config even when we have. This leads to sweeps running the same 10 configs repeatedly forever.

This PR converts whole-number floats to integers when computing the hash, so that now the values hash to the same thing.

# Testing

This has been manually tested by running the same sweep as in the Jira ticket and getting exactly 160 runs.