### PR TITLE
fix(sweeps): strip runtime-injected keys from dict-valued params in grid search deduplication

### DIFF
--- a/src/sweeps/grid_search.py
+++ b/src/sweeps/grid_search.py
@@ -113,6 +113,19 @@ def grid_search_next_runs(
     param_hashes = [
         [yaml_hash(value) for value in p.config["values"]] for p in discrete_params
     ]
+
+    # for dict-valued params, collect the union of keys across all grid point
+    # values. this is used to strip runtime injected keys before hashing, so
+    # that extra keys don't cause yaml_hash mismatches and duplicate suggestions.
+    param_known_keys: typing.Dict[str, typing.Set[str]] = {}
+    for name, values in zip(param_names, param_values):
+        keys: typing.Set[str] = set()
+        for val in values:
+            if isinstance(val, dict):
+                keys.update(val.keys())
+        if keys:
+            param_known_keys[name] = keys
+
     value_hash_lookup = {
         name: dict(zip(hashes, vals))
         for name, vals, hashes in zip(param_names, param_values, param_hashes)
@@ -134,7 +147,14 @@ def grid_search_next_runs(
             nested_key.insert(1, "value")
 
             if util.dict_has_nested_key(run.config, nested_key):
-                hashes.append(yaml_hash(util.get_nested_value(run.config, nested_key)))
+                run_value = util.get_nested_value(run.config, nested_key)
+                if name in param_known_keys and isinstance(run_value, dict):
+                    run_value = {
+                        k: v
+                        for k, v in run_value.items()
+                        if k in param_known_keys[name]
+                    }
+                hashes.append(yaml_hash(run_value))
             else:
                 missing_params.append(name)
 
@@ -146,9 +166,9 @@ def grid_search_next_runs(
                     "expected_params": expected_tuple_len,
                     "found_params": len(hashes),
                     "missing_params": missing_params,
-                    "config_top_level_keys": sorted(run.config.keys())
-                    if run.config
-                    else [],
+                    "config_top_level_keys": (
+                        sorted(run.config.keys()) if run.config else []
+                    ),
                 },
             )
 

--- a/tests/test_grid_search.py
+++ b/tests/test_grid_search.py
@@ -1,9 +1,9 @@
-from typing import List, Sequence, Tuple
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 import numpy as np
 import pytest
 from sweeps.config import SweepConfig
-from sweeps.grid_search import yaml_hash
+from sweeps.grid_search import yaml_hash, grid_search_next_runs
 from sweeps.run import RunState, SweepRun, next_run, next_runs
 
 
@@ -425,3 +425,299 @@ def test_nested_grid_search_advances():
 
 def test_yaml_hash_float():
     assert yaml_hash(3000000.0) == yaml_hash(3000000)
+
+
+# Tests for grid_search_next_runs, focused on dict-valued parameter deduplication.
+
+
+def _make_grid_config(
+    param_name: str,
+    values: List,
+    extra_params: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    parameters: Dict[str, Any] = {
+        param_name: {"values": values},
+    }
+    if extra_params:
+        parameters.update(extra_params)
+    return {
+        "method": "grid",
+        "parameters": parameters,
+    }
+
+
+def _make_run(config: dict, name: str = "run") -> SweepRun:
+    return SweepRun(name=name, state=RunState.finished, config=config)
+
+
+# --- Dict-valued parameter tests ---
+
+
+def test_dict_valued_param_with_injected_key():
+    """A run whose dict-valued param has an extra runtime key should still
+    be recognized as covering its grid point.
+
+    This is the core config pollution bug: sinergym injects env_name into
+    env_params.value, changing yaml_hash so anaconda re-suggests the point.
+    """
+    grid_values = [
+        {"env_id": "Env-v0", "max_steps": 1000},
+        {"env_id": "Env-v1", "max_steps": 2000},
+    ]
+    sweep_config = _make_grid_config("env_params", grid_values)
+
+    runs = [
+        _make_run(
+            {
+                "env_params": {
+                    "value": {
+                        "env_id": "Env-v0",
+                        "max_steps": 1000,
+                        "env_name": "SAC_abc123",
+                    }
+                }
+            },
+            name="run-0",
+        ),
+        _make_run(
+            {
+                "env_params": {
+                    "value": {
+                        "env_id": "Env-v1",
+                        "max_steps": 2000,
+                        "env_name": "SAC_def456",
+                    }
+                }
+            },
+            name="run-1",
+        ),
+    ]
+
+    result = grid_search_next_runs(runs, sweep_config)
+    assert result == [
+        None
+    ], f"Expected no more suggestions (all grid points covered), got {result}"
+
+
+def test_dict_valued_param_without_injection():
+    """Baseline: runs with clean configs (no injected keys) should be
+    recognized as covering their grid points."""
+    grid_values = [
+        {"env_id": "Env-v0", "max_steps": 1000},
+        {"env_id": "Env-v1", "max_steps": 2000},
+    ]
+    sweep_config = _make_grid_config("env_params", grid_values)
+
+    runs = [
+        _make_run(
+            {"env_params": {"value": {"env_id": "Env-v0", "max_steps": 1000}}},
+            name="run-0",
+        ),
+        _make_run(
+            {"env_params": {"value": {"env_id": "Env-v1", "max_steps": 2000}}},
+            name="run-1",
+        ),
+    ]
+
+    result = grid_search_next_runs(runs, sweep_config)
+    assert result == [None]
+
+
+def test_dict_valued_param_missing_run_still_suggested():
+    """When only some grid points are covered (even with injected keys),
+    the uncovered point should still be suggested."""
+    grid_values = [
+        {"env_id": "Env-v0", "max_steps": 1000},
+        {"env_id": "Env-v1", "max_steps": 2000},
+        {"env_id": "Env-v2", "max_steps": 3000},
+    ]
+    sweep_config = _make_grid_config("env_params", grid_values)
+
+    runs = [
+        _make_run(
+            {
+                "env_params": {
+                    "value": {
+                        "env_id": "Env-v0",
+                        "max_steps": 1000,
+                        "env_name": "SAC_abc",
+                    }
+                }
+            },
+            name="run-0",
+        ),
+        _make_run(
+            {
+                "env_params": {
+                    "value": {
+                        "env_id": "Env-v2",
+                        "max_steps": 3000,
+                        "env_name": "SAC_def",
+                    }
+                }
+            },
+            name="run-2",
+        ),
+    ]
+
+    result = grid_search_next_runs(runs, sweep_config)
+    assert len(result) == 1
+    assert result[0] is not None
+    assert result[0].config["env_params"]["value"] == {
+        "env_id": "Env-v1",
+        "max_steps": 2000,
+    }
+
+
+def test_dict_valued_param_multiple_injected_keys():
+    """Multiple extra keys injected should all be stripped."""
+    grid_values = [
+        {"env_id": "Env-v0", "reward_scale": 0.5},
+    ]
+    sweep_config = _make_grid_config("env_params", grid_values)
+
+    runs = [
+        _make_run(
+            {
+                "env_params": {
+                    "value": {
+                        "env_id": "Env-v0",
+                        "reward_scale": 0.5,
+                        "env_name": "SAC_run1",
+                        "created_at": "2026-03-27",
+                        "internal_id": 42,
+                    }
+                }
+            },
+            name="run-0",
+        ),
+    ]
+
+    result = grid_search_next_runs(runs, sweep_config)
+    assert result == [None]
+
+
+# --- Scalar-valued parameter tests ---
+
+
+def test_scalar_param_unaffected():
+    """Scalar-valued parameters should work exactly as before."""
+    sweep_config = _make_grid_config("learning_rate", [0.001, 0.01, 0.1])
+
+    runs = [
+        _make_run({"learning_rate": {"value": 0.001}}, name="run-0"),
+        _make_run({"learning_rate": {"value": 0.01}}, name="run-1"),
+    ]
+
+    result = grid_search_next_runs(runs, sweep_config)
+    assert len(result) == 1
+    assert result[0] is not None
+    assert result[0].config["learning_rate"]["value"] == 0.1
+
+
+def test_scalar_param_all_covered():
+    """All scalar grid points covered -> no suggestions."""
+    sweep_config = _make_grid_config("batch_size", [16, 32, 64])
+
+    runs = [
+        _make_run({"batch_size": {"value": 16}}, name="run-0"),
+        _make_run({"batch_size": {"value": 32}}, name="run-1"),
+        _make_run({"batch_size": {"value": 64}}, name="run-2"),
+    ]
+
+    result = grid_search_next_runs(runs, sweep_config)
+    assert result == [None]
+
+
+# --- Mixed parameter tests ---
+
+
+def test_mixed_scalar_and_dict_params():
+    """Grid with both scalar and dict-valued params, dict has injected keys."""
+    sweep_config = {
+        "method": "grid",
+        "parameters": {
+            "algorithm": {"value": "SAC"},
+            "env_params": {
+                "values": [
+                    {"env_id": "Env-v0", "max_steps": 1000},
+                    {"env_id": "Env-v1", "max_steps": 2000},
+                ],
+            },
+        },
+    }
+
+    runs = [
+        _make_run(
+            {
+                "algorithm": {"value": "SAC"},
+                "env_params": {
+                    "value": {
+                        "env_id": "Env-v0",
+                        "max_steps": 1000,
+                        "env_name": "SAC_abc",
+                    }
+                },
+            },
+            name="run-0",
+        ),
+        _make_run(
+            {
+                "algorithm": {"value": "SAC"},
+                "env_params": {
+                    "value": {
+                        "env_id": "Env-v1",
+                        "max_steps": 2000,
+                        "env_name": "SAC_def",
+                    }
+                },
+            },
+            name="run-1",
+        ),
+    ]
+
+    result = grid_search_next_runs(runs, sweep_config)
+    assert result == [None]
+
+
+def test_nested_dict_value_with_injected_key():
+    """Dict values with nested dicts should also be handled correctly."""
+    grid_values = [
+        {"env_id": "Env-v0", "reward_kwargs": {"lambda_energy": 0.001}},
+    ]
+    sweep_config = _make_grid_config("env_params", grid_values)
+
+    runs = [
+        _make_run(
+            {
+                "env_params": {
+                    "value": {
+                        "env_id": "Env-v0",
+                        "reward_kwargs": {"lambda_energy": 0.001},
+                        "env_name": "SAC_injected",
+                    }
+                }
+            },
+            name="run-0",
+        ),
+    ]
+
+    result = grid_search_next_runs(runs, sweep_config)
+    assert result == [None]
+
+
+def test_empty_runs_suggests_first_grid_point():
+    """No runs -> suggest the first grid point (regression guard)."""
+    grid_values = [
+        {"env_id": "Env-v0", "max_steps": 1000},
+        {"env_id": "Env-v1", "max_steps": 2000},
+    ]
+    sweep_config = _make_grid_config("env_params", grid_values)
+
+    result = grid_search_next_runs([], sweep_config)
+    assert len(result) == 1
+    assert result[0] is not None
+    assert result[0].config["env_params"]["value"] == {
+        "env_id": "Env-v0",
+        "max_steps": 1000,
+    }


### PR DESCRIPTION
## Description

This PR fixes a bug which causes duplicate args to be suggested when a user injects additional key values into a dict sweep arg.

### Root Cause

`yaml_hash()` in `grid_search_next_runs` hashes the entire dictionary which could have runtime injected keys present, resulting in a hash that doesn't match the original sweep args.

### Repro

Create a sweep config  with a key that's a dictionary.
```yaml
method: grid
parameters:
  env_params:
    values:
      - max_episode_steps: 1000
        reward_scale: 0.1
      - max_episode_steps: 1100
        reward_scale: 0.2
  algorithm:
    value: SAC
  learning_rate:
    values:
      - 0.001
      - 0.0003
```

At runtime, inject a new key into the dict.
```python
config = dict(wandb.config)
config["env_params"]["env_name"] = f"{timestamp}_{random_id}"
wandb.init(config=config)
```

`yaml_hash(run.config["env_params"]["value"])` will now include env_name, resulting in a different hash. Grid search will think the grid point hasn't been covered and resuggest it.

### Solution

1. Collect the union of all keys that appear in the sweep config for each dict valued parameter.
2. When using `yaml_hash` to hash a run config's value, strip it to only known keys from the sweep config.

## Testing
[x] Tested in local dev