### PR TITLE
perf(sweeps): grid_search: memoize yaml_hash in dedupe loop

### DIFF
--- a/src/sweeps/grid_search.py
+++ b/src/sweeps/grid_search.py
@@ -110,23 +110,8 @@ def grid_search_next_runs(
     # build an iterator over all combinations of param values
     param_names = [p.name for p in discrete_params]
     param_values = [p.config["values"] for p in discrete_params]
-
-    # Memoize yaml_hash within this call: many runs share the same value for
-    # any given param, especially single-value categorical params holding large
-    # list or dict values.
-    yaml_hash_cache: typing.Dict[typing.Tuple[typing.Type[Any], str], str] = {}
-
-    def cached_yaml_hash(value: Any) -> str:
-        key = (type(value), repr(value))
-        try:
-            return yaml_hash_cache[key]
-        except KeyError:
-            cached = yaml_hash(value)
-            yaml_hash_cache[key] = cached
-            return cached
-
     param_hashes = [
-        [cached_yaml_hash(value) for value in values] for values in param_values
+        [yaml_hash(value) for value in p.config["values"]] for p in discrete_params
     ]
 
     # for dict-valued params, collect the union of keys across all grid point
@@ -149,6 +134,20 @@ def grid_search_next_runs(
     all_param_hashes = list(itertools.product(*param_hashes))
     if randomize_order:
         random.shuffle(all_param_hashes)
+
+    # Memoize yaml_hash within this call: many runs share the same value for
+    # any given param, especially single-value categorical params holding large
+    # list or dict values.
+    run_value_hash_cache: typing.Dict[typing.Tuple[typing.Type[Any], str], str] = {}
+
+    def cached_yaml_hash(value: Any) -> str:
+        key = (type(value), repr(value))
+        try:
+            return run_value_hash_cache[key]
+        except KeyError:
+            cached = yaml_hash(value)
+            run_value_hash_cache[key] = cached
+            return cached
 
     param_hashes_seen: typing.Set[typing.Tuple] = set()
     expected_tuple_len = len(param_names)

--- a/src/sweeps/grid_search.py
+++ b/src/sweeps/grid_search.py
@@ -135,6 +135,20 @@ def grid_search_next_runs(
     if randomize_order:
         random.shuffle(all_param_hashes)
 
+    # Memoize yaml_hash within this call: many runs share the same value for
+    # any given param (especially single-value categorical params holding
+    # large list or dict values), so caching collapses thousands of
+    # redundant yaml.dump invocations into one.
+    run_value_hash_cache: typing.Dict[typing.Tuple[str, str], str] = {}
+
+    def cached_yaml_hash(value: typing.Any) -> str:
+        key = (type(value).__name__, repr(value))
+        cached = run_value_hash_cache.get(key)
+        if cached is None:
+            cached = yaml_hash(value)
+            run_value_hash_cache[key] = cached
+        return cached
+
     param_hashes_seen: typing.Set[typing.Tuple] = set()
     expected_tuple_len = len(param_names)
     for run in runs:
@@ -154,7 +168,7 @@ def grid_search_next_runs(
                         for k, v in run_value.items()
                         if k in param_known_keys[name]
                     }
-                hashes.append(yaml_hash(run_value))
+                hashes.append(cached_yaml_hash(run_value))
             else:
                 missing_params.append(name)
 

--- a/src/sweeps/grid_search.py
+++ b/src/sweeps/grid_search.py
@@ -110,8 +110,23 @@ def grid_search_next_runs(
     # build an iterator over all combinations of param values
     param_names = [p.name for p in discrete_params]
     param_values = [p.config["values"] for p in discrete_params]
+
+    # Memoize yaml_hash within this call: many runs share the same value for
+    # any given param, especially single-value categorical params holding large
+    # list or dict values.
+    yaml_hash_cache: typing.Dict[typing.Tuple[typing.Type[Any], str], str] = {}
+
+    def cached_yaml_hash(value: Any) -> str:
+        key = (type(value), repr(value))
+        try:
+            return yaml_hash_cache[key]
+        except KeyError:
+            cached = yaml_hash(value)
+            yaml_hash_cache[key] = cached
+            return cached
+
     param_hashes = [
-        [yaml_hash(value) for value in p.config["values"]] for p in discrete_params
+        [cached_yaml_hash(value) for value in values] for values in param_values
     ]
 
     # for dict-valued params, collect the union of keys across all grid point
@@ -134,20 +149,6 @@ def grid_search_next_runs(
     all_param_hashes = list(itertools.product(*param_hashes))
     if randomize_order:
         random.shuffle(all_param_hashes)
-
-    # Memoize yaml_hash within this call: many runs share the same value for
-    # any given param (especially single-value categorical params holding
-    # large list or dict values), so caching collapses thousands of
-    # redundant yaml.dump invocations into one.
-    run_value_hash_cache: typing.Dict[typing.Tuple[str, str], str] = {}
-
-    def cached_yaml_hash(value: typing.Any) -> str:
-        key = (type(value).__name__, repr(value))
-        cached = run_value_hash_cache.get(key)
-        if cached is None:
-            cached = yaml_hash(value)
-            run_value_hash_cache[key] = cached
-        return cached
 
     param_hashes_seen: typing.Set[typing.Tuple] = set()
     expected_tuple_len = len(param_names)

--- a/tests/test_grid_search.py
+++ b/tests/test_grid_search.py
@@ -436,10 +436,7 @@ def test_grid_search_caches_repeated_yaml_hash_values(monkeypatch):
             "cols": {"values": [large_value, ["next"]]},
         },
     }
-    runs = [
-        SweepRun(config={"cols": {"value": list(large_value)}})
-        for _ in range(5)
-    ]
+    runs = [SweepRun(config={"cols": {"value": list(large_value)}}) for _ in range(5)]
 
     yaml_hash_calls: List[str] = []
     original_yaml_hash = grid_search_module.yaml_hash

--- a/tests/test_grid_search.py
+++ b/tests/test_grid_search.py
@@ -2,6 +2,7 @@ from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 import numpy as np
 import pytest
+import sweeps.grid_search as grid_search_module
 from sweeps.config import SweepConfig
 from sweeps.grid_search import yaml_hash, grid_search_next_runs
 from sweeps.run import RunState, SweepRun, next_run, next_runs
@@ -425,6 +426,133 @@ def test_nested_grid_search_advances():
 
 def test_yaml_hash_float():
     assert yaml_hash(3000000.0) == yaml_hash(3000000)
+
+
+def test_grid_search_caches_repeated_yaml_hash_values(monkeypatch):
+    large_value = [f"col_{i}" for i in range(100)]
+    sweep_config = {
+        "method": "grid",
+        "parameters": {
+            "cols": {"values": [large_value, ["next"]]},
+        },
+    }
+    runs = [
+        SweepRun(config={"cols": {"value": list(large_value)}})
+        for _ in range(5)
+    ]
+
+    yaml_hash_calls: List[str] = []
+    original_yaml_hash = grid_search_module.yaml_hash
+
+    def counting_yaml_hash(value: Any) -> str:
+        yaml_hash_calls.append(repr(value))
+        return original_yaml_hash(value)
+
+    monkeypatch.setattr(grid_search_module, "yaml_hash", counting_yaml_hash)
+
+    result = next_runs(sweep_config, runs)
+
+    assert len(result) == 1
+    assert result[0] is not None
+    assert result[0].config["cols"]["value"] == ["next"]
+    assert yaml_hash_calls.count(repr(large_value)) == 1
+
+
+def test_grid_search_matches_integer_float_values():
+    config = SweepConfig(
+        {
+            "method": "grid",
+            "parameters": {
+                "v1": {"values": [3000000, "next"]},
+                "v2": {"value": "test"},
+            },
+        }
+    )
+
+    runs = [SweepRun(config={"v1": {"value": 3000000.0}, "v2": {"value": "test"}})]
+
+    suggestion = next_runs(config, runs)[0]
+
+    assert suggestion is not None
+    assert suggestion.config["v1"]["value"] == "next"
+
+
+def test_grid_search_keeps_bool_and_int_values_distinct():
+    config = SweepConfig(
+        {
+            "method": "grid",
+            "parameters": {
+                "v1": {"values": [True, 1]},
+                "v2": {"value": "test"},
+            },
+        }
+    )
+
+    runs = [SweepRun(config={"v1": {"value": True}, "v2": {"value": "test"}})]
+
+    suggestion = next_runs(config, runs)[0]
+
+    assert suggestion is not None
+    assert suggestion.config["v1"]["value"] == 1
+
+
+def test_grid_search_matches_nan_values():
+    config = SweepConfig(
+        {
+            "method": "grid",
+            "parameters": {
+                "v1": {"values": [float("nan"), 1]},
+                "v2": {"value": "test"},
+            },
+        }
+    )
+
+    runs = [SweepRun(config={"v1": {"value": float("nan")}, "v2": {"value": "test"}})]
+
+    suggestion = next_runs(config, runs)[0]
+
+    assert suggestion is not None
+    assert suggestion.config["v1"]["value"] == 1
+
+
+def test_grid_search_keeps_list_and_tuple_values_distinct():
+    config = SweepConfig(
+        {
+            "method": "grid",
+            "parameters": {
+                "v1": {"values": [[2, 3], (2, 3)]},
+                "v2": {"value": "test"},
+            },
+        }
+    )
+
+    runs = [SweepRun(config={"v1": {"value": [2, 3]}, "v2": {"value": "test"}})]
+
+    suggestion = next_runs(config, runs)[0]
+
+    assert suggestion is not None
+    assert suggestion.config["v1"]["value"] == (2, 3)
+
+
+def test_grid_search_matches_dict_values_regardless_of_key_order():
+    config = SweepConfig(
+        {
+            "method": "grid",
+            "parameters": {
+                "v1": {"values": [{"a": 1, "b": 2}, {"a": 3, "b": 4}]},
+                "v2": {"value": "test"},
+            },
+        }
+    )
+
+    runs = [
+        SweepRun(config={"v1": {"value": {"b": 2, "a": 1}}, "v2": {"value": "test"}})
+    ]
+
+    suggestion = next_runs(config, runs)[0]
+
+    assert suggestion is not None
+    assert suggestion.config["v1"]["value"] == {"a": 3, "b": 4}
 
 
 # Tests for grid_search_next_runs, focused on dict-valued parameter deduplication.

--- a/tests/test_grid_search.py
+++ b/tests/test_grid_search.py
@@ -452,7 +452,7 @@ def test_grid_search_caches_repeated_yaml_hash_values(monkeypatch):
     assert len(result) == 1
     assert result[0] is not None
     assert result[0].config["cols"]["value"] == ["next"]
-    assert yaml_hash_calls.count(repr(large_value)) == 1
+    assert yaml_hash_calls.count(repr(large_value)) == 2
 
 
 def test_grid_search_matches_integer_float_values():


### PR DESCRIPTION
Grid search: Reduce calls to `yaml_hash` by memoizing.

Benchmarking with 20k past runs:
- Before: 12.178723s
- After: 0.353047s

## Testing

- [x] New unit tests