### PR TITLE
feat(sweeps): support external schedulers and MOO

### DIFF
--- a/src/sweeps/config/__init__.py
+++ b/src/sweeps/config/__init__.py
@@ -5,6 +5,7 @@ from .schema import (
     ParamValidationError,
     fill_parameter,
     fill_validate_early_terminate,
+    fill_validate_metrics,
     fill_validate_schema,
 )
 
@@ -14,5 +15,6 @@ __all__ = [
     "fill_validate_schema",
     "fill_parameter",
     "fill_validate_early_terminate",
+    "fill_validate_metrics",
     "ParamValidationError",
 ]

--- a/src/sweeps/config/cfg.py
+++ b/src/sweeps/config/cfg.py
@@ -26,6 +26,15 @@ def schema_violations_from_proposed_config(config: Dict) -> List[str]:
         raise ValueError("Sweep config must be parsable as a JSON object.")
 
     method = config.get("method")
+    scheduler = config.get("scheduler")
+    has_search_space = isinstance(scheduler, dict) and bool(
+        scheduler.get("search_space")
+    )
+
+    if "parameters" not in config and not has_search_space:
+        schema_violation_messages.append(
+            "`parameters` is required unless `scheduler.search_space` is set."
+        )
 
     if "metric" in config and "metrics" in config:
         schema_violation_messages.append(

--- a/src/sweeps/config/cfg.py
+++ b/src/sweeps/config/cfg.py
@@ -25,6 +25,44 @@ def schema_violations_from_proposed_config(config: Dict) -> List[str]:
     if not isinstance(config, dict):
         raise ValueError("Sweep config must be parsable as a JSON object.")
 
+    method = config.get("method")
+
+    if "metric" in config and "metrics" in config:
+        schema_violation_messages.append(
+            "`metric` and `metrics` cannot both be set: use `metric` for a "
+            "single objective, or `metrics` for multi-objective optimization."
+        )
+    elif "metrics" in config and method is not None and method != "custom":
+        schema_violation_messages.append(
+            f"`metrics` requires `method: custom` (got `method: {method}`): "
+            "multi-objective optimization is only supported with a custom "
+            "scheduler."
+        )
+
+    if "scheduler" in config:
+        if method is not None and method != "custom":
+            schema_violation_messages.append(
+                f"`scheduler` requires `method: custom` (got `method: {method}`)."
+            )
+
+        if "early_terminate" in config:
+            schema_violation_messages.append(
+                "`early_terminate` cannot be used together with `scheduler`: "
+                "early termination must be implemented by the custom scheduler "
+                "itself."
+            )
+
+        # only the wandb engine is implemented so far - the other engines are
+        # part of the schema so that configs can be written against the
+        # eventual API, but they cannot be used yet
+        if isinstance(config["scheduler"], dict):
+            engine = config["scheduler"].get("engine")
+            if engine in ("optuna", "ax"):
+                schema_violation_messages.append(
+                    f"scheduler.engine '{engine}' is not yet supported; "
+                    "only 'wandb' is currently available"
+                )
+
     # validate min/max - this cannot be done with jsonschema
     # because it does not support comparing values within
     # a json document. so we do it manually here:

--- a/src/sweeps/config/schema.json
+++ b/src/sweeps/config/schema.json
@@ -781,8 +781,7 @@
     }
   },
   "required": [
-    "method",
-    "parameters"
+    "method"
   ],
   "additionalProperties": false,
   "properties": {

--- a/src/sweeps/config/schema.json
+++ b/src/sweeps/config/schema.json
@@ -652,6 +652,79 @@
         }
       ]
     },
+    "metric": {
+      "type": "object",
+      "description": "Metric to optimize",
+      "required": [
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of metric"
+        },
+        "goal": {
+          "type": "string",
+          "description": "Possible values: minimize, maximize",
+          "enum": [
+            "minimize",
+            "maximize"
+          ],
+          "default": "minimize"
+        },
+        "target": {
+          "type": "number",
+          "description": "The sweep will finish once any run achieves this value"
+        },
+        "impute": {
+          "type": "string",
+          "description": "Metric value to use in bayes search for runs that fail, crash, or are killed",
+          "enum": ["latest", "best", "worst"],
+          "default": "worst"
+        },
+        "impute_while_running": {
+          "type": "string",
+          "description": "Appends a calculated metric even when epochs are in a running state",
+          "enum": ["latest", "best", "worst", "false"],
+          "default": "false"
+        }
+      }
+    },
+    "scheduler": {
+      "type": "object",
+      "description": "Configuration for a custom hyperparameter optimization scheduler. Requires `method: custom`, and cannot be used together with `early_terminate`.",
+      "required": [
+        "engine",
+        "source",
+        "optimizer",
+        "search_space"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "engine": {
+          "type": "string",
+          "description": "Possible values: optuna, ax, wandb",
+          "enum": [
+            "optuna",
+            "ax",
+            "wandb"
+          ]
+        },
+        "source": {
+          "type": "string",
+          "description": "Path to the file containing the optimizer and search space functions"
+        },
+        "optimizer": {
+          "type": "string",
+          "description": "Name of the function in `source` that builds the study/optimizer"
+        },
+        "search_space": {
+          "type": "string",
+          "description": "Name of the function in `source` that defines the search space"
+        }
+      }
+    },
     "hyperband_stopping": {
       "type": "object",
       "description": "Speed up hyperparameter search by killing off runs that appear to have lower performance than successful training runs",
@@ -788,43 +861,18 @@
       "exclusiveMinimum": 0
     },
     "metric": {
-      "type": "object",
-      "description": "Metric to optimize",
-      "required": [
-        "name"
-      ],
-      "additionalProperties": false,
-      "properties": {
-        "name": {
-          "type": "string",
-          "description": "Name of metric"
-        },
-        "goal": {
-          "type": "string",
-          "description": "Possible values: minimize, maximize",
-          "enum": [
-            "minimize",
-            "maximize"
-          ],
-          "default": "minimize"
-        },
-        "target": {
-          "type": "number",
-          "description": "The sweep will finish once any run achieves this value"
-        },
-        "impute": {
-          "type": "string",
-          "description": "Metric value to use in bayes search for runs that fail, crash, or are killed",
-          "enum": ["latest", "best", "worst"],
-          "default": "worst"
-        },
-        "impute_while_running": {
-          "type": "string",
-          "description": "Appends a calculated metric even when epochs are in a running state",
-          "enum": ["latest", "best", "worst", "false"],
-          "default": "false"
-        }
+      "$ref": "#/definitions/metric"
+    },
+    "metrics": {
+      "type": "array",
+      "description": "List of metrics to optimize, for multi-objective optimization. Cannot be used together with `metric`, and requires `method: custom`.",
+      "minItems": 2,
+      "items": {
+        "$ref": "#/definitions/metric"
       }
+    },
+    "scheduler": {
+      "$ref": "#/definitions/scheduler"
     },
     "early_terminate": {
       "oneOf": [

--- a/src/sweeps/config/schema.json
+++ b/src/sweeps/config/schema.json
@@ -675,7 +675,7 @@
         },
         "target": {
           "type": "number",
-          "description": "The sweep will finish once any run achieves this value"
+          "description": "The sweep will finish once any run reaches the goal for this value"
         },
         "impute": {
           "type": "string",

--- a/src/sweeps/config/schema.py
+++ b/src/sweeps/config/schema.py
@@ -181,6 +181,46 @@ def fill_validate_metric(d: Dict) -> Dict:
     return d
 
 
+def fill_validate_metrics(d: Dict) -> Dict:
+    d = deepcopy(d)
+
+    if "metrics" in d:
+        if not isinstance(d["metrics"], list):
+            raise ValueError(
+                f"invalid type for metrics: expected list, got {type(d['metrics'])}"
+            )
+
+        metric_schema = dereferenced_sweep_config_jsonschema["properties"]["metrics"][
+            "items"
+        ]
+
+        filled_metrics = []
+        for metric in d["metrics"]:
+            if not isinstance(metric, dict):
+                raise ValueError(
+                    f"invalid type for metric: expected dict, got {type(metric)}"
+                )
+            metric = deepcopy(metric)
+            if "goal" in metric:
+                if metric["goal"] not in metric_schema["properties"]["goal"]["enum"]:
+                    # let it be filled in by the schema default
+                    del metric["goal"]
+
+            if "impute" in metric:
+                if (
+                    metric["impute"]
+                    not in metric_schema["properties"]["impute"]["enum"]
+                ):
+                    # let it be filled in by the schema default
+                    del metric["impute"]
+
+            filler = DefaultFiller(schema=metric_schema, format_checker=format_checker)
+            filler.validate(metric)
+            filled_metrics.append(metric)
+        d["metrics"] = filled_metrics
+    return d
+
+
 def fill_validate_early_terminate(d: Dict) -> Dict:
     d = deepcopy(d)
     if d["early_terminate"]["type"] == "hyperband":

--- a/src/sweeps/config/schema.py
+++ b/src/sweeps/config/schema.py
@@ -245,18 +245,19 @@ def fill_validate_schema(d: Dict) -> Dict:
     validated = deepcopy(d)
 
     # update the parameters
-    filled = {}
-    for k, v in validated["parameters"].items():
-        try:
-            result = fill_parameter(k, v)
-        except ParamValidationError:
-            continue
-        else:
-            if result is None:
-                raise jsonschema.ValidationError(f"Parameter {k} is malformed")
-            _, config = result
-            filled[k] = config
-    validated["parameters"] = filled
+    if "parameters" in validated:
+        filled = {}
+        for k, v in validated["parameters"].items():
+            try:
+                result = fill_parameter(k, v)
+            except ParamValidationError:
+                continue
+            else:
+                if result is None:
+                    raise jsonschema.ValidationError(f"Parameter {k} is malformed")
+                _, config = result
+                filled[k] = config
+        validated["parameters"] = filled
 
     if "early_terminate" in validated:
         validated = fill_validate_early_terminate(validated)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -333,3 +333,56 @@ def test_metrics_requires_custom_method_error_message_is_specific():
 
     with pytest.raises(jsonschema.ValidationError, match="method: custom"):
         _ = config.SweepConfig(invalid_config)
+
+
+def test_parameters_not_required_when_scheduler_defines_search_space():
+    valid_config = {
+        "method": "custom",
+        "scheduler": {
+            "engine": "wandb",
+            "source": "scheduler.py",
+            "optimizer": "build_study",
+            "search_space": "search_space",
+        },
+    }
+
+    sweep_config = config.SweepConfig(valid_config)
+    assert "parameters" not in sweep_config
+
+
+def test_parameters_still_allowed_alongside_scheduler_search_space():
+    valid_config = {
+        "method": "custom",
+        "scheduler": {
+            "engine": "wandb",
+            "source": "scheduler.py",
+            "optimizer": "build_study",
+            "search_space": "search_space",
+        },
+        "parameters": {"v1": {"values": [1, 2, 3]}},
+    }
+
+    sweep_config = config.SweepConfig(valid_config)
+    assert sweep_config["parameters"]["v1"]["values"] == [1, 2, 3]
+
+
+def test_parameters_still_required_without_scheduler():
+    invalid_config = {"method": "bayes"}
+
+    with pytest.raises(jsonschema.ValidationError, match="`parameters` is required"):
+        _ = config.SweepConfig(invalid_config)
+
+
+def test_parameters_still_required_when_scheduler_has_no_search_space():
+    invalid_config = {
+        "method": "custom",
+        "scheduler": {
+            "engine": "wandb",
+            "source": "scheduler.py",
+            "optimizer": "build_study",
+            "search_space": "",
+        },
+    }
+
+    with pytest.raises(jsonschema.ValidationError, match="`parameters` is required"):
+        _ = config.SweepConfig(invalid_config)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -77,3 +77,259 @@ def test_categorical_prob_grid():
     with pytest.raises(ValueError):
         sweep_config = config.SweepConfig(invalid_config)
         grid_search.grid_search_next_runs([], sweep_config)
+
+
+def test_metrics_multi_objective_with_custom_method():
+    valid_config = {
+        "method": "custom",
+        "metrics": [
+            {"name": "loss", "goal": "minimize"},
+            {"name": "accuracy", "goal": "maximize"},
+        ],
+        "parameters": {"v1": {"values": [1, 2, 3]}},
+    }
+
+    sweep_config = config.SweepConfig(valid_config)
+    assert len(sweep_config["metrics"]) == 2
+
+
+def test_metrics_requires_custom_method():
+    invalid_config = {
+        "method": "bayes",
+        "metrics": [
+            {"name": "loss", "goal": "minimize"},
+            {"name": "accuracy", "goal": "maximize"},
+        ],
+        "parameters": {"v1": {"values": [1, 2, 3]}},
+    }
+
+    with pytest.raises(jsonschema.ValidationError):
+        _ = config.SweepConfig(invalid_config)
+
+
+def test_metric_and_metrics_mutually_exclusive():
+    invalid_config = {
+        "method": "custom",
+        "metric": {"name": "loss"},
+        "metrics": [
+            {"name": "loss", "goal": "minimize"},
+            {"name": "accuracy", "goal": "maximize"},
+        ],
+        "parameters": {"v1": {"values": [1, 2, 3]}},
+    }
+
+    with pytest.raises(jsonschema.ValidationError):
+        _ = config.SweepConfig(invalid_config)
+
+
+def test_metrics_requires_at_least_two():
+    invalid_config = {
+        "method": "custom",
+        "metrics": [{"name": "loss", "goal": "minimize"}],
+        "parameters": {"v1": {"values": [1, 2, 3]}},
+    }
+
+    with pytest.raises(jsonschema.ValidationError):
+        _ = config.SweepConfig(invalid_config)
+
+
+def test_metrics_filled_with_defaults():
+    valid_config = {
+        "method": "custom",
+        "metrics": [{"name": "loss"}, {"name": "accuracy"}],
+        "parameters": {"v1": {"values": [1, 2, 3]}},
+    }
+
+    filled = config.fill_validate_metrics(valid_config)
+    assert filled["metrics"][0]["goal"] == "minimize"
+    assert filled["metrics"][1]["goal"] == "minimize"
+
+
+def test_fill_validate_metrics_rejects_non_list():
+    invalid_config = {
+        "method": "custom",
+        "metrics": "not-a-list",
+        "parameters": {"v1": {"values": [1, 2, 3]}},
+    }
+
+    with pytest.raises(ValueError, match="expected list"):
+        config.fill_validate_metrics(invalid_config)
+
+
+def test_fill_validate_metrics_rejects_non_dict_items():
+    invalid_config = {
+        "method": "custom",
+        "metrics": [{"name": "loss"}, "not-a-dict"],
+        "parameters": {"v1": {"values": [1, 2, 3]}},
+    }
+
+    with pytest.raises(ValueError, match="expected dict"):
+        config.fill_validate_metrics(invalid_config)
+
+
+def test_fill_validate_metrics_invalid_goal_replaced_with_default():
+    valid_config = {
+        "method": "custom",
+        "metrics": [
+            {"name": "loss", "goal": "not-a-real-goal"},
+            {"name": "accuracy", "goal": "maximize"},
+        ],
+        "parameters": {"v1": {"values": [1, 2, 3]}},
+    }
+
+    filled = config.fill_validate_metrics(valid_config)
+    assert filled["metrics"][0]["goal"] == "minimize"
+    assert filled["metrics"][1]["goal"] == "maximize"
+
+
+def test_fill_validate_metrics_invalid_impute_replaced_with_default():
+    valid_config = {
+        "method": "custom",
+        "metrics": [
+            {"name": "loss", "impute": "not-a-real-impute-strategy"},
+            {"name": "accuracy", "impute": "best"},
+        ],
+        "parameters": {"v1": {"values": [1, 2, 3]}},
+    }
+
+    filled = config.fill_validate_metrics(valid_config)
+    assert filled["metrics"][0]["impute"] == "worst"
+    assert filled["metrics"][1]["impute"] == "best"
+
+
+def test_scheduler_wandb_engine_valid():
+    valid_config = {
+        "method": "custom",
+        "scheduler": {
+            "engine": "wandb",
+            "source": "scheduler.py",
+            "optimizer": "build_study",
+            "search_space": "search_space",
+        },
+        "parameters": {"v1": {"values": [1, 2, 3]}},
+    }
+
+    sweep_config = config.SweepConfig(valid_config)
+    assert sweep_config["scheduler"]["engine"] == "wandb"
+
+
+@pytest.mark.parametrize("engine", ["optuna", "ax"])
+def test_scheduler_unavailable_engine_raises(engine):
+    invalid_config = {
+        "method": "custom",
+        "scheduler": {
+            "engine": engine,
+            "source": "scheduler.py",
+            "optimizer": "build_study",
+            "search_space": "search_space",
+        },
+        "parameters": {"v1": {"values": [1, 2, 3]}},
+    }
+
+    with pytest.raises(jsonschema.ValidationError):
+        _ = config.SweepConfig(invalid_config)
+
+
+def test_scheduler_invalid_engine_rejected():
+    invalid_config = {
+        "method": "custom",
+        "scheduler": {
+            "engine": "not-a-real-engine",
+            "source": "scheduler.py",
+            "optimizer": "build_study",
+            "search_space": "search_space",
+        },
+        "parameters": {"v1": {"values": [1, 2, 3]}},
+    }
+
+    with pytest.raises(jsonschema.ValidationError):
+        _ = config.SweepConfig(invalid_config)
+
+
+def test_scheduler_missing_required_field():
+    invalid_config = {
+        "method": "custom",
+        "scheduler": {
+            "engine": "wandb",
+            "source": "scheduler.py",
+            "optimizer": "build_study",
+        },
+        "parameters": {"v1": {"values": [1, 2, 3]}},
+    }
+
+    with pytest.raises(jsonschema.ValidationError):
+        _ = config.SweepConfig(invalid_config)
+
+
+def test_scheduler_requires_custom_method():
+    invalid_config = {
+        "method": "grid",
+        "scheduler": {
+            "engine": "wandb",
+            "source": "scheduler.py",
+            "optimizer": "build_study",
+            "search_space": "search_space",
+        },
+        "parameters": {"v1": {"values": [1, 2, 3]}},
+    }
+
+    with pytest.raises(jsonschema.ValidationError, match="method: custom"):
+        _ = config.SweepConfig(invalid_config)
+
+
+def test_scheduler_and_early_terminate_mutually_exclusive():
+    invalid_config = {
+        "method": "custom",
+        "scheduler": {
+            "engine": "wandb",
+            "source": "scheduler.py",
+            "optimizer": "build_study",
+            "search_space": "search_space",
+        },
+        "early_terminate": {"type": "hyperband", "min_iter": 3},
+        "parameters": {"v1": {"values": [1, 2, 3]}},
+    }
+
+    with pytest.raises(jsonschema.ValidationError, match="early_terminate"):
+        _ = config.SweepConfig(invalid_config)
+
+
+def test_early_terminate_without_scheduler_still_works():
+    valid_config = {
+        "method": "bayes",
+        "metric": {"name": "loss", "goal": "minimize"},
+        "early_terminate": {"type": "hyperband", "min_iter": 3},
+        "parameters": {"v1": {"values": [1, 2, 3]}},
+    }
+
+    sweep_config = config.SweepConfig(valid_config)
+    assert sweep_config["early_terminate"]["type"] == "hyperband"
+
+
+def test_metric_and_metrics_error_message_is_specific():
+    invalid_config = {
+        "method": "custom",
+        "metric": {"name": "loss"},
+        "metrics": [
+            {"name": "loss", "goal": "minimize"},
+            {"name": "accuracy", "goal": "maximize"},
+        ],
+        "parameters": {"v1": {"values": [1, 2, 3]}},
+    }
+
+    with pytest.raises(jsonschema.ValidationError, match="cannot both be set"):
+        _ = config.SweepConfig(invalid_config)
+
+
+def test_metrics_requires_custom_method_error_message_is_specific():
+    invalid_config = {
+        "method": "bayes",
+        "metrics": [
+            {"name": "loss", "goal": "minimize"},
+            {"name": "accuracy", "goal": "maximize"},
+        ],
+        "parameters": {"v1": {"values": [1, 2, 3]}},
+    }
+
+    with pytest.raises(jsonschema.ValidationError, match="method: custom"):
+        _ = config.SweepConfig(invalid_config)


### PR DESCRIPTION
- Support MOO through the metrics: key
- metrics: needs to have at least 2 items
- metrics: and metric: are mutually exclusive
- metrics: requires method: custom
- scheduler and early_terminate are mutually exclusive
- scheduler: engine: only supports wandb, other values throw an unsupported error