### PR TITLE
fix(sweeps): ensure that local controller cannot be used with local scheduler

### DIFF
--- a/src/sweeps/config/cfg.py
+++ b/src/sweeps/config/cfg.py
@@ -54,6 +54,12 @@ def schema_violations_from_proposed_config(config: Dict) -> List[str]:
                 f"`scheduler` requires `method: custom` (got `method: {method}`)."
             )
 
+        if "controller" in config and config["controller"]["type"] == "local":
+            schema_violation_messages.append(
+                "`controller: type:local` cannot be used together with `scheduler`: "
+                "use `scheduler` instead of `controller`."
+            )
+
         if "early_terminate" in config:
             schema_violation_messages.append(
                 "`early_terminate` cannot be used together with `scheduler`: "

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -338,6 +338,28 @@ def test_scheduler_and_early_terminate_mutually_exclusive():
         _ = config.SweepConfig(invalid_config)
 
 
+def test_scheduler_and_controller_mutually_exclusive():
+    invalid_config = {
+        "method": "custom",
+        "scheduler": {
+            "engine": "wandb",
+            "source": "scheduler.py",
+            "optimizer": "build_study",
+            "search_space": "search_space",
+        },
+        "controller": {"type": "local"},
+        "parameters": {"v1": {"values": [1, 2, 3]}},
+    }
+
+    with pytest.raises(jsonschema.ValidationError, match="controller"):
+        _ = config.SweepConfig(invalid_config)
+
+    # cloud is acceptable
+    invalid_config["controller"]["type"] = "cloud"
+    cfg = config.SweepConfig(invalid_config)
+    assert cfg["controller"]["type"] == "cloud"
+
+
 def test_early_terminate_without_scheduler_still_works():
     valid_config = {
         "method": "bayes",


### PR DESCRIPTION
The scheduler config supersedes the old local controller implementation. Thus we make both these config keys mutually exclusive to prevent users from using both at the same time and breaking the sweep.