### PR TITLE
Require `method: custom` for optuna/ax scheduler engines

### DIFF
--- a/src/sweeps/config/cfg.py
+++ b/src/sweeps/config/cfg.py
@@ -17,6 +17,8 @@ from .schema import (
 
 _SUPPORTED_METHODS_BY_ENGINE = {
     "wandb": ["grid", "bayes", "random"],
+    "optuna": ["custom"],
+    "ax": ["custom"],
 }
 
 
@@ -65,9 +67,6 @@ def schema_violations_from_proposed_config(config: Dict) -> List[str]:
                 "itself."
             )
 
-        # only the wandb engine is implemented so far - the other engines are
-        # part of the schema so that configs can be written against the
-        # eventual API, but they cannot be used yet
         if isinstance(scheduler, dict):
             engine = scheduler.get("engine")
             if engine not in _SUPPORTED_METHODS_BY_ENGINE:
@@ -78,7 +77,10 @@ def schema_violations_from_proposed_config(config: Dict) -> List[str]:
             elif method not in _SUPPORTED_METHODS_BY_ENGINE[engine]:
                 schema_violation_messages.append(
                     f"`scheduler.engine: {engine}` does not support `method: {method}`. "
-                    f"supported methods are: {', '.join(_SUPPORTED_METHODS_BY_ENGINE[engine])}"
+                    "supported methods are: "
+                    + ", ".join(
+                        f"`method: {m}`" for m in _SUPPORTED_METHODS_BY_ENGINE[engine]
+                    )
                 )
 
     # validate min/max - this cannot be done with jsonschema

--- a/src/sweeps/config/schema.json
+++ b/src/sweeps/config/schema.json
@@ -693,7 +693,7 @@
     },
     "scheduler": {
       "type": "object",
-      "description": "Configuration for a custom hyperparameter optimization scheduler. Requires `method: custom`, and cannot be used together with `early_terminate`.",
+      "description": "Configuration for a custom hyperparameter optimization scheduler. `engine: wandb` requires `method: grid`, `random` or `bayes`; `engine: optuna` and `engine: ax` require `method: custom`. Cannot be used together with `early_terminate`.",
       "required": [
         "engine"
       ],

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -214,9 +214,9 @@ def test_scheduler_wandb_engine_valid():
 
 
 @pytest.mark.parametrize("engine", ["optuna", "ax"])
-def test_scheduler_unavailable_engine_raises(engine):
-    invalid_config = {
-        "method": "bayes",
+def test_scheduler_external_engine_requires_custom_method(engine):
+    valid_config = {
+        "method": "custom",
         "scheduler": {
             "engine": engine,
             "source": "scheduler.py",
@@ -226,7 +226,25 @@ def test_scheduler_unavailable_engine_raises(engine):
         "parameters": {"v1": {"values": [1, 2, 3]}},
     }
 
-    with pytest.raises(jsonschema.ValidationError):
+    sweep_config = config.SweepConfig(valid_config)
+    assert sweep_config["scheduler"]["engine"] == engine
+
+
+@pytest.mark.parametrize("engine", ["optuna", "ax"])
+@pytest.mark.parametrize("method", ["grid", "random", "bayes"])
+def test_scheduler_external_engine_rejects_wandb_methods(engine, method):
+    invalid_config = {
+        "method": method,
+        "scheduler": {
+            "engine": engine,
+            "source": "scheduler.py",
+            "optimizer": "build_study",
+            "search_space": "search_space",
+        },
+        "parameters": {"v1": {"values": [1, 2, 3]}},
+    }
+
+    with pytest.raises(jsonschema.ValidationError, match="method: custom"):
         _ = config.SweepConfig(invalid_config)
 
 


### PR DESCRIPTION
## Summary
`scheduler.engine: optuna` and `scheduler.engine: ax` were rejected outright by config validation. They are now accepted, but only with `method: custom`; `engine: wandb` continues to require `method: grid | random | bayes`.

```python
_SUPPORTED_METHODS_BY_ENGINE = {
    "wandb": ["grid", "bayes", "random"],
    "optuna": ["custom"],
    "ax": ["custom"],
}
```

The engine/method mismatch error now lists methods as `` `method: x` `` so it matches the wording of the other `method: custom` errors. Schema description for `scheduler` updated to document the mapping; tests updated to cover both directions for optuna/ax.

Link to Devin session: https://coreweave.devinenterprise.com/sessions/71a11719543544858580ce263664369a
Open in Devin Desktop: https://coreweave.devinenterprise.com/desktop/session/71a11719543544858580ce263664369a?variant=devin
Requested by: @kmikowicz-wandb